### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.0
       with:
         token: ${{ secrets.VERSION_COMMIT_PAT }}
     - name: get version

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -14,16 +14,16 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.0
       with:
         path: RePoE
     - name: checkout pypoe
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.0
       with:
         repository: lvlvllvlvllvlvl/PyPoE
         path: PyPoE
     - name: checkout pob
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.0
       with:
         repository: PathOfBuildingCommunity/PathOfBuilding
         path: PathOfBuilding

--- a/.github/workflows/update_workflows.yml
+++ b/.github/workflows/update_workflows.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.0
         with:
           sparse-checkout: .github
           token: ${{ secrets.VERSION_COMMIT_PAT }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.0](https://github.com/actions/checkout/releases/tag/v4.2.0)** on 2024-09-25T17:52:55Z
