### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4.2.0
+      uses: actions/checkout@v4.2.2
       with:
         token: ${{ secrets.VERSION_COMMIT_PAT }}
     - name: get version

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -14,16 +14,16 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4.2.0
+        uses: actions/checkout@v4.2.2
         with:
           path: RePoE
       - name: checkout pypoe
-        uses: actions/checkout@v4.2.0
+        uses: actions/checkout@v4.2.2
         with:
           repository: lvlvllvlvllvlvl/PyPoE
           path: PyPoE
       - name: checkout pob
-        uses: actions/checkout@v4.2.0
+        uses: actions/checkout@v4.2.2
         with:
           repository: PathOfBuildingCommunity/PathOfBuilding
           path: PathOfBuilding
@@ -37,7 +37,7 @@ jobs:
       - name: Install poetry
         run: pipx install poetry
       - name: setup python
-        uses: actions/setup-python@v5.2.0
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: "3.11"
           cache: poetry

--- a/.github/workflows/update_workflows.yml
+++ b/.github/workflows/update_workflows.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.2.0
+      - uses: actions/checkout@v4.2.2
         with:
           sparse-checkout: .github
           token: ${{ secrets.VERSION_COMMIT_PAT }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.3.0](https://github.com/actions/setup-python/releases/tag/v5.3.0)** on 2024-10-24T14:15:17Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
