### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -24,6 +24,6 @@ jobs:
       id: set-version
       run: echo "version=$(cat RePoE/version.txt)" >> "$GITHUB_OUTPUT"
     - name: commit changes
-      uses: stefanzweifel/git-auto-commit-action@v5.0.1
+      uses: stefanzweifel/git-auto-commit-action@v5.1.0
       with:
         commit_message: "Version ${{ steps.set-version.outputs.version }}"

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -76,7 +76,7 @@ jobs:
         working-directory: RePoE/RePoE/data/
       - name: commit changes
         id: autocommit
-        uses: stefanzweifel/git-auto-commit-action@v5.0.1
+        uses: stefanzweifel/git-auto-commit-action@v5.1.0
         with:
           repository: RePoE
           commit_message: "[skip ci] Automated export"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action)** published a new release **[v5.1.0](https://github.com/stefanzweifel/git-auto-commit-action/releases/tag/v5.1.0)** on 2025-01-11T07:12:05Z
