### PR TITLE
add icon files to poe2 skill_gems and extract skill images

### DIFF
--- a/RePoE/data/poe2/skill_gems.json
+++ b/RePoE/data/poe2/skill_gems.json
@@ -14,6 +14,7 @@
     "grants_skills": [
       "IceNovaPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressIceNova.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -47,6 +48,7 @@
     "grants_skills": [
       "LeapSlamPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteLeapSlam.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -82,6 +84,7 @@
     "grants_skills": [
       "ShieldChargePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteShieldCharge.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -117,6 +120,7 @@
     "grants_skills": [
       "DetonateDeadPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchDetonateDead.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -149,6 +153,7 @@
     "grants_skills": [
       "VolatileDeadPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/VolatileDeadWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -181,6 +186,7 @@
     "grants_skills": [
       "SupportAddedFireDamagePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AddedFireDamageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -212,6 +218,7 @@
     "grants_skills": [
       "SupportFasterAttackPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FasterAttack.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -242,6 +249,7 @@
     "grants_skills": [
       "SupportMultipleProjectilesPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MultipleProjectilesSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -272,6 +280,7 @@
     "grants_skills": [
       "SupportFasterProjectilesPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FasterProjectilesSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -302,6 +311,7 @@
     "grants_skills": [
       "SupportAddedColdDamagePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AddedColdDamageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -333,6 +343,7 @@
     "grants_skills": [
       "SupportAdditionalAccuracyPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AdditionalAccuracy.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -363,6 +374,7 @@
     "grants_skills": [
       "SupportIncreasedAreaOfEffectPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IncreasedAreaOfEffectSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -393,6 +405,7 @@
     "grants_skills": [
       "SupportAddedLightningDamagePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AddedLightningDamageSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -424,6 +437,7 @@
     "grants_skills": [
       "RaiseZombiePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchRaiseZombie.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -456,6 +470,7 @@
     "grants_skills": [
       "SupportInspirationPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/Inspiration.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -485,6 +500,7 @@
     "grants_skills": [
       "SupportIncreasedCriticalDamagePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IncreasedCritDamageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -515,6 +531,7 @@
     "grants_skills": [
       "SupportKnockbackPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/KnockbackSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -544,6 +561,7 @@
     "grants_skills": [
       "SupportLifeLeechPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LifeLeechSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -575,6 +593,7 @@
     "grants_skills": [
       "SupportManaLeechPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ManaLeechSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -606,6 +625,7 @@
     "grants_skills": [
       "SupportAddedChaosDamagePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AddedChaosDamageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -637,6 +657,7 @@
     "grants_skills": [
       "FlickerStrikePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkFlickerStrikeTeleport.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -670,6 +691,7 @@
     "grants_skills": [
       "SparkPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressSpark.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -701,6 +723,7 @@
     "grants_skills": [
       "IceSpearPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/HuntressIceSpear.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -734,6 +757,7 @@
     "grants_skills": [
       "SupportPiercePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PierceSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -762,6 +786,7 @@
     "grants_skills": [
       "SummonSpectrePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchSpectre.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -793,6 +818,7 @@
     "grants_skills": [
       "FrostWallPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressFrostWall.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -824,6 +850,7 @@
     "grants_skills": [
       "ShockNovaPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/ShockNova.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -857,6 +884,7 @@
     "grants_skills": [
       "SupportMeleePhysicalDamagePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MeleePhysicalDamageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -889,6 +917,7 @@
     "grants_skills": [
       "SupportFasterCastPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FasterCastSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -919,6 +948,7 @@
     "grants_skills": [
       "TemporalChainsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/temporalchains.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -952,6 +982,7 @@
     "grants_skills": [
       "EnfeeblePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/enfeeble.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -985,6 +1016,7 @@
     "grants_skills": [
       "SnipersMarkPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/projectileweakness.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -1017,6 +1049,7 @@
     "grants_skills": [
       "DespairPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Despair.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1051,6 +1084,7 @@
     "grants_skills": [
       "LightningWarpPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressLightningWarp.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1084,6 +1118,7 @@
     "grants_skills": [
       "ArmourBreakerPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteHeavyStrike.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -1118,6 +1153,7 @@
     "grants_skills": [
       "RainOfArrowsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerRainOfArrowsSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -1151,6 +1187,7 @@
     "grants_skills": [
       "SupportConcentratedEffectPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ConcentratedEffectSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1181,6 +1218,7 @@
     "grants_skills": [
       "SupportBloodlustPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BloodlustSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -1213,6 +1251,7 @@
     "grants_skills": [
       "FirestormPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchFirestorm.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1248,6 +1287,7 @@
     "grants_skills": [
       "FallingThunderPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkLightningStrike.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -1281,6 +1321,7 @@
     "grants_skills": [
       "PowerSiphonPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/PowerSiphonWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1312,6 +1353,7 @@
     "grants_skills": [
       "LightningArrowPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerLightningArrow.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -1344,6 +1386,7 @@
     "grants_skills": [
       "DisciplinePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DisciplineWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 75,
@@ -1377,6 +1420,7 @@
       "ShockwaveTotemPlayer",
       "ShockwaveTotemQuakePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteShockwaveTotem.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -1414,6 +1458,7 @@
     "grants_skills": [
       "SupportBlindPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BlindSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -1443,6 +1488,7 @@
     "grants_skills": [
       "ArcPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressArc.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1475,6 +1521,7 @@
     "grants_skills": [
       "ArcticArmourPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressArcticArmour.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1509,6 +1556,7 @@
     "grants_skills": [
       "SupportFirePenetrationPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FirePenetrationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -1539,6 +1587,7 @@
     "grants_skills": [
       "SupportColdPenetrationPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ColdPenetrationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1569,6 +1618,7 @@
     "grants_skills": [
       "SupportLightningPenetrationPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LightningPenetrationSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -1599,6 +1649,7 @@
     "grants_skills": [
       "SupportChainPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ChainSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -1630,6 +1681,7 @@
     "grants_skills": [
       "SupportForkPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ForkSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -1660,6 +1712,7 @@
     "grants_skills": [
       "FlammabilityPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Flammability.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1694,6 +1747,7 @@
     "grants_skills": [
       "HypothermiaPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Frostbite.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1728,6 +1782,7 @@
     "grants_skills": [
       "ConductivityPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Conductivity.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1762,6 +1817,7 @@
     "grants_skills": [
       "IncineratePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressIncinerate.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1797,6 +1853,7 @@
     "grants_skills": [
       "SupportSpellEchoPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/SpellEchoSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1828,6 +1885,7 @@
     "grants_skills": [
       "SupportElementalArmyPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ElementalArmySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1858,6 +1916,7 @@
     "grants_skills": [
       "SupportSlowerProjectilesPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/SlowerProjectilesSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -1886,6 +1945,7 @@
     "grants_skills": [
       "PurityOfFirePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/PurityofFireWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 75,
@@ -1917,6 +1977,7 @@
     "grants_skills": [
       "PurityOfIcePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/PurityofColdWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 75,
@@ -1948,6 +2009,7 @@
     "grants_skills": [
       "PurityOfLightningPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/PurityofLightningWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 75,
@@ -1981,6 +2043,7 @@
     "grants_skills": [
       "FlameblastPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressFlameblast.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2015,6 +2078,7 @@
     "grants_skills": [
       "BarragePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerBarrageSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -2047,6 +2111,7 @@
     "grants_skills": [
       "BallLightningPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressBallLightning.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2081,6 +2146,7 @@
     "grants_skills": [
       "BoneOfferingPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchBoneOffering.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2116,6 +2182,7 @@
     "grants_skills": [
       "HeraldOfAshPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/HeraldOfAshSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -2151,6 +2218,7 @@
     "grants_skills": [
       "HeraldOfIcePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/HeraldOfIceSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -2189,6 +2257,7 @@
     "grants_skills": [
       "HeraldOfThunderPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/HeraldOfThunderSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -2226,6 +2295,7 @@
       "BlasphemyPlayer",
       "SupportBlasphemyPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchBlasphemy.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2261,6 +2331,7 @@
       "InfernalCryPlayer",
       "InfernalCryCorpseExplosionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteInfernalCry.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -2295,6 +2366,7 @@
     "grants_skills": [
       "SupportIceBitePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IceBiteSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2327,6 +2399,7 @@
     "grants_skills": [
       "SupportGlaciationPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/HypothermiaSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2357,6 +2430,7 @@
     "grants_skills": [
       "SupportChanceToShockPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ConductionSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -2385,6 +2459,7 @@
     "grants_skills": [
       "RollingMagmaPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressRollingMagma.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2418,6 +2493,7 @@
     "grants_skills": [
       "FrostBombPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressFrostBomb.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2452,6 +2528,7 @@
     "grants_skills": [
       "OrbOfStormsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressOrbOfStorms.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2488,6 +2565,7 @@
     "grants_skills": [
       "EarthquakePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteEarthquake.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -2522,6 +2600,7 @@
     "grants_skills": [
       "ContagionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchContagion.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2553,6 +2632,7 @@
     "grants_skills": [
       "WitherPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Wither.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2587,6 +2667,7 @@
     "grants_skills": [
       "EssenceDrainPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchEssenceDrain.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2620,6 +2701,7 @@
     "grants_skills": [
       "SupportControlledDestructionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ControlledDestructionSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2651,6 +2733,7 @@
     "grants_skills": [
       "SunderPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteSunder.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -2685,6 +2768,7 @@
     "grants_skills": [
       "FrostboltPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressFrostbolt.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2719,6 +2803,7 @@
     "grants_skills": [
       "SupportElementalFocusPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ElementalFocusSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2746,6 +2831,7 @@
     "grants_skills": [
       "DarkPactPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SkeletalChains.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2780,6 +2866,7 @@
     "grants_skills": [
       "SummonSkeletalWarriorsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchWarriorSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2813,6 +2900,7 @@
       "SummonSkeletalReaversPlayer",
       "CommandSkeletalReaversPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchReaverSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2845,6 +2933,7 @@
     "grants_skills": [
       "SummonSkeletalBrutesPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchBruteSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2878,6 +2967,7 @@
       "SummonSkeletalSnipersPlayer",
       "CommandSkeletalSniperPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchArcherSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2913,6 +3003,7 @@
       "SummonSkeletalFrostMagesPlayer",
       "CommandSkeletalFrostMagePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchFrostSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2946,6 +3037,7 @@
       "SummonSkeletalStormMagesPlayer",
       "CommandSkeletalStormMagePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchStormSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2979,6 +3071,7 @@
       "SummonSkeletalArsonistsPlayer",
       "CommandSkeletalArsonistPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchArsonistSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3012,6 +3105,7 @@
     "grants_skills": [
       "SummonSkeletalClericsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchClericSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3043,6 +3137,7 @@
     "grants_skills": [
       "SupportWildfirePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IgniteProliferationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3074,6 +3169,7 @@
     "grants_skills": [
       "SupportChanceToBleedPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ChanceToBleedSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -3104,6 +3200,7 @@
     "grants_skills": [
       "SupportChanceToPoisonPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ChanceToPoisonSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -3134,6 +3231,7 @@
     "grants_skills": [
       "SupportMaimPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MaimSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -3164,6 +3262,7 @@
     "grants_skills": [
       "SupportImmolatePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ImmolationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -3195,6 +3294,7 @@
     "grants_skills": [
       "SupportLastingShockPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LastingShockSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -3225,6 +3325,7 @@
     "grants_skills": [
       "SupportBrutalityPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BrutalitySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -3255,6 +3356,7 @@
     "grants_skills": [
       "SupportMomentumPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MomentumSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -3284,6 +3386,7 @@
     "grants_skills": [
       "SupportArcaneSurgePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ArcaneSurgeSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3315,6 +3418,7 @@
     "grants_skills": [
       "VulnerabilityPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/vulnerability.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3349,6 +3453,7 @@
     "grants_skills": [
       "SupportWitheringTouchPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/WitheringTouchSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3378,6 +3483,7 @@
     "grants_skills": [
       "SoulrendPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Soulrend.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3411,6 +3517,7 @@
     "grants_skills": [
       "SupportUnleashPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/UnleashSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3441,6 +3548,7 @@
     "grants_skills": [
       "SupportCloseCombatPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CloseCombatSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -3471,6 +3579,7 @@
     "grants_skills": [
       "SupportRagePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/RageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -3503,6 +3612,7 @@
       "PlagueBearerPlayer",
       "PlagueBearerNovaPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerPlagueBearerSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -3538,6 +3648,7 @@
     "grants_skills": [
       "SupportFeedingFrenzyPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FeedingFrenzySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3568,6 +3679,7 @@
     "grants_skills": [
       "SupportMeatShieldPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MeatShield.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -3598,6 +3710,7 @@
     "grants_skills": [
       "SupportInfernalLegionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/InfernalLegionSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -3631,6 +3744,7 @@
       "ArtilleryBallistaPlayer",
       "ArtilleryBallistaProjectilePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MercArtilleryBallista.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -3666,6 +3780,7 @@
     "grants_skills": [
       "SupportSecondWindPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/SecondWindSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -3695,6 +3810,7 @@
     "grants_skills": [
       "SeismicCryPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteSeismicCry.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -3728,6 +3844,7 @@
     "grants_skills": [
       "EarthshatterPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteEarthshatter.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -3760,6 +3877,7 @@
     "grants_skills": [
       "SigilOfPowerPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SigilofPowerWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3792,6 +3910,7 @@
     "grants_skills": [
       "FlameWallPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressFlameWall.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3826,6 +3945,7 @@
       "ViciousHexSupportPlayer",
       "DoomBlastPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ImpendingDoomSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3860,6 +3980,7 @@
     "grants_skills": [
       "HexblastPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchHexBlast.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3891,6 +4012,7 @@
     "grants_skills": [
       "ExsanguinatePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BloodTendrilsSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -3922,6 +4044,7 @@
     "grants_skills": [
       "ReapPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Bloodreap.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -3956,6 +4079,7 @@
     "grants_skills": [
       "SupportBloodMagicPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BloodMagicSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -3985,6 +4109,7 @@
     "grants_skills": [
       "SupportBeheadPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BeheadSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4017,6 +4142,7 @@
     "grants_skills": [
       "SupportExecutePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ExecuteSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4046,6 +4172,7 @@
     "grants_skills": [
       "BoneshatterPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteBoneshatter.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4079,6 +4206,7 @@
     "grants_skills": [
       "EyeOfWinterPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressEyeofWinter.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -4109,6 +4237,7 @@
     "grants_skills": [
       "TornadoPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DruidTornado.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -4143,6 +4272,7 @@
     "grants_skills": [
       "SupportOverchargePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/OverchargeSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4173,6 +4303,7 @@
     "grants_skills": [
       "LightningConduitPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressLightningConduit.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -4204,6 +4335,7 @@
     "grants_skills": [
       "GalvanicFieldPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/GalvanicFieldWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -4240,6 +4372,7 @@
     "grants_skills": [
       "VolcanicFissurePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteVolcanicFissure.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4274,6 +4407,7 @@
     "grants_skills": [
       "RapidAssaultPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/HuntressRapidAssault.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4305,6 +4439,7 @@
     "grants_skills": [
       "DisengagePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RetreatingThrow.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4338,6 +4473,7 @@
     "grants_skills": [
       "EngagePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/AdvancingStrike.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4372,6 +4508,7 @@
     "grants_skills": [
       "WhirlingSlashPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/HuntressWhirlingSlash.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4403,6 +4540,7 @@
     "grants_skills": [
       "SpearfieldPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/HuntressSpearField.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4436,6 +4574,7 @@
       "DemonMagusPlayer",
       "SupportDemonMagusPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SpellcastingMinionSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -4467,6 +4606,7 @@
     "grants_skills": [
       "StormSpearPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/HuntressStormSpear.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4498,6 +4638,7 @@
     "grants_skills": [
       "BlazingLancePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/HuntressBlazingLance.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4528,6 +4669,7 @@
     "grants_skills": [
       "AxeChopPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/axedmg.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4558,6 +4700,7 @@
     "grants_skills": [
       "AxeSlashPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/damageaxe.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4590,6 +4733,7 @@
     "grants_skills": [
       "WhirlingAssaultPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkWhirlingAssault.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -4623,6 +4767,7 @@
     "grants_skills": [
       "RollingSlamPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteDoubleSlam.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4656,6 +4801,7 @@
     "grants_skills": [
       "EscapeShotPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerFrostEscapeShot.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4689,6 +4835,7 @@
     "grants_skills": [
       "SuperchargedSlamPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteSuperchargedSlam.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4721,6 +4868,7 @@
     "grants_skills": [
       "EvasiveStrikePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/clawsofthepride.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4754,6 +4902,7 @@
     "grants_skills": [
       "GaleStrikePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkGaleStrikeSwing.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -4784,6 +4933,7 @@
     "grants_skills": [
       "BladeDancePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DoubleSlash.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -4815,6 +4965,7 @@
     "grants_skills": [
       "ClawRakePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/icondualswing.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4846,6 +4997,7 @@
     "grants_skills": [
       "SpinningFlailPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/StaffNodeDefensive.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -4877,6 +5029,7 @@
     "grants_skills": [
       "AxeExecutePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/AxeNotable1.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4907,6 +5060,7 @@
     "grants_skills": [
       "AxeLeapingChopPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/AxesandAttackSpeed.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4937,6 +5091,7 @@
     "grants_skills": [
       "AxeWhirlingSlashPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/cleavage.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4967,6 +5122,7 @@
     "grants_skills": [
       "AxeRaisedChopPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/MeleeSplashNode.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4998,6 +5154,7 @@
     "grants_skills": [
       "AxeHeavyCleavePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/StudiousCombatant.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5028,6 +5185,7 @@
     "grants_skills": [
       "KnifeFlipPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/shadowprojectiles.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5061,6 +5219,7 @@
     "grants_skills": [
       "WaveOfFrostPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkFreezingBackflip.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5093,6 +5252,7 @@
     "grants_skills": [
       "SwordLungePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/fencing.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -5123,6 +5283,7 @@
     "grants_skills": [
       "SwordLeapSlashPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/fencing.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -5155,6 +5316,7 @@
     "grants_skills": [
       "IceStrikePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkComboAttack.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5189,6 +5351,7 @@
     "grants_skills": [
       "SupportJaggedGroundPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/JaggedGroundSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5223,6 +5386,7 @@
     "grants_skills": [
       "SupportInevitableCriticalsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/InevitableCriticalsSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -5253,6 +5417,7 @@
     "grants_skills": [
       "RuthlessSupportPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/RuthlessSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5282,6 +5447,7 @@
     "grants_skills": [
       "LessDurationSupportPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LessDurationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5312,6 +5478,7 @@
     "grants_skills": [
       "FistOfWarSupportPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FistOfWarSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5344,6 +5511,7 @@
     "grants_skills": [
       "UnbreakableSupportPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/UnbreakableSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5373,6 +5541,7 @@
     "grants_skills": [
       "MoreDurationSupportPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MoreDurationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5403,6 +5572,7 @@
     "grants_skills": [
       "ImpactShockwaveSupportPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ImpactShockwaveSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5435,6 +5605,7 @@
     "grants_skills": [
       "SupportHexBloomPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/HexBloomSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -5466,6 +5637,7 @@
     "grants_skills": [
       "GlacialCascadePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkGlacialCascade.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5500,6 +5672,7 @@
     "grants_skills": [
       "CometPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressComet.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -5530,6 +5703,7 @@
     "grants_skills": [
       "BladeNovaPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/shadowprojectiles.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5561,6 +5735,7 @@
     "grants_skills": [
       "FlameSlicePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/TwoHandedMeleeDamage.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -5591,6 +5766,7 @@
     "grants_skills": [
       "RingOfBladesPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/ViperStrike.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5620,6 +5796,7 @@
     "grants_skills": [
       "ComboKnifeThrowPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/shadowprojectiles.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5651,6 +5828,7 @@
     "grants_skills": [
       "TripleSlashPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/fencing.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -5681,6 +5859,7 @@
     "grants_skills": [
       "HyperSlashPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/ChargedAttack.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5711,6 +5890,7 @@
     "grants_skills": [
       "ShadowDashPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/ChargedDash.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5741,6 +5921,7 @@
     "grants_skills": [
       "ShadowAmbushPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/iconblinkstrike.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5771,6 +5952,7 @@
     "grants_skills": [
       "StaffConsecratePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/BuffIcons/consecrated.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -5805,6 +5987,7 @@
       "RipwireBallistaPlayer",
       "RipwireBallistaProjectilePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MercRipwireBallista.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -5838,6 +6021,7 @@
     "grants_skills": [
       "ManaTempestPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressManaTempest.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -5870,6 +6054,7 @@
     "grants_skills": [
       "KillingPalmPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkKillingPalm.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5905,6 +6090,7 @@
       "ShatteringPalmPlayer",
       "ShatteringPalmExplosionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkShatteringPalm.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5938,6 +6124,7 @@
     "grants_skills": [
       "VolcanoPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DruidVolcano.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -5971,6 +6158,7 @@
     "grants_skills": [
       "SummonWolfCompanionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DruidSummonWolf.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -6002,6 +6190,7 @@
     "grants_skills": [
       "SupportChillingIcePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FrozenNexusSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6031,6 +6220,7 @@
     "grants_skills": [
       "SupportFrozenVortexPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FrozenVortexSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6061,6 +6251,7 @@
     "grants_skills": [
       "SpinningThrowPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/ghostlythrow.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -6092,6 +6283,7 @@
     "grants_skills": [
       "SpiralVolleyPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerSpiralVolleySkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -6122,6 +6314,7 @@
     "grants_skills": [
       "BearMaulPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DruidBearMaul.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -6152,6 +6345,7 @@
     "grants_skills": [
       "DodgeRollPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Rolldodge.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -6179,6 +6373,7 @@
     "grants_skills": [
       "ShadowThiefSlashPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/AreaofEffectofMinionsNotable.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -6208,6 +6403,7 @@
     "grants_skills": [
       "LeapingAxeCatchPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/iconleapslam.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -6238,6 +6434,7 @@
     "grants_skills": [
       "StormBladePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Upheaval.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -6269,6 +6466,7 @@
     "grants_skills": [
       "PlungingBladePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/TectonicSlam.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -6298,6 +6496,7 @@
     "grants_skills": [
       "WolfHowlPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DruidWolfHowl.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -6326,6 +6525,7 @@
     "grants_skills": [
       "SpiralThrowPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/ghostlythrow.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -6355,6 +6555,7 @@
     "grants_skills": [
       "WolfLeapAttackPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DruidWolfLeapAttack.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -6385,6 +6586,7 @@
     "grants_skills": [
       "LightningBoltPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/LightningBoltSkillStaff.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6415,6 +6617,7 @@
     "grants_skills": [
       "BearRampagePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DruidBearRampage.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -6449,6 +6652,7 @@
     "grants_skills": [
       "SupportShockManaRegenerationPlayer"
     ],
+    "icon_dds_file": null,
     "requirement_weights": {
       "dexterity": 40,
       "intelligence": 60,
@@ -6478,6 +6682,7 @@
     "grants_skills": [
       "SupportEnergyShieldOnShockKillPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ShockSiphonSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6506,6 +6711,7 @@
     "grants_skills": [
       "StaffUnleashNextSpellPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/UnleashSkillStaff.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6538,6 +6744,7 @@
     "grants_skills": [
       "SupportCoursingCurrentPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ShockingProliferationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6569,6 +6776,7 @@
     "grants_skills": [
       "SupportLastingFrostPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DeepFreezeSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6597,6 +6805,7 @@
     "grants_skills": [
       "LightningStormPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/LightningStormSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6628,6 +6837,7 @@
     "grants_skills": [
       "SupportChanceToFreezePlayer"
     ],
+    "icon_dds_file": null,
     "requirement_weights": {
       "dexterity": 60,
       "intelligence": 40,
@@ -6657,6 +6867,7 @@
     "grants_skills": [
       "SupportChanceToIgnitePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IgnitionSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -6687,6 +6898,7 @@
     "grants_skills": [
       "SupportDeadlyIgnitesPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/SearingFlameSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -6717,6 +6929,7 @@
     "grants_skills": [
       "SupportIgniteDurationPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/EternalFlameSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -6745,6 +6958,7 @@
     "grants_skills": [
       "SupportMinionHarvestPlayer"
     ],
+    "icon_dds_file": null,
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6773,6 +6987,7 @@
     "grants_skills": [
       "BearSlamPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DruidBearSlam.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -6805,6 +7020,7 @@
       "BearWarcryMetaPlayer",
       "SupportBearWarcryPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DruidBearWarcry.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -6839,6 +7055,7 @@
       "SupportMetaCastOnShockPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnShockSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6871,6 +7088,7 @@
     "grants_skills": [
       "SupportInvocationPlayer"
     ],
+    "icon_dds_file": null,
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6904,6 +7122,7 @@
       "SupportMetaCastOnFreezePlayer",
       "SupportInvisibleMetaGemSupport"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnFreezeSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6940,6 +7159,7 @@
       "SupportMetaCastOnIgnitePlayer",
       "SupportInvisibleMetaGemSupport"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnIgniteSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6974,6 +7194,7 @@
       "SupportMetaCastOnMeleeKillPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnMeleeKillSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -7007,6 +7228,7 @@
       "SupportMetaCastOnDeathPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DeathWalk.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -7042,6 +7264,7 @@
       "SupportMetaCastOnCritPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnCritSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7075,6 +7298,7 @@
       "SupportMetaCastWhenStunnedPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/TectonicSlam.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7108,6 +7332,7 @@
       "SupportMetaCastWhenDamageTakenPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/icononfire.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -7141,6 +7366,7 @@
     "grants_skills": [
       "SupportExploitWeaknessPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ExploitWeaknessSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -7171,6 +7397,7 @@
     "grants_skills": [
       "SupportDevastatePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DevastateSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -7205,6 +7432,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7239,6 +7467,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7273,6 +7502,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7307,6 +7537,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 33,
       "intelligence": 34,
@@ -7341,6 +7572,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7375,6 +7607,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7410,6 +7643,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7444,6 +7678,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7478,6 +7713,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7514,6 +7750,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7548,6 +7785,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7584,6 +7822,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7618,6 +7857,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7654,6 +7894,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7688,6 +7929,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7726,6 +7968,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7760,6 +8003,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7787,6 +8031,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7814,6 +8059,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7841,6 +8087,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7868,6 +8115,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7895,6 +8143,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7922,6 +8171,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7949,6 +8199,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7976,6 +8227,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -8003,6 +8255,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -8030,6 +8283,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -8064,6 +8318,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8100,6 +8355,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8136,6 +8392,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8172,6 +8429,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8208,6 +8466,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8246,6 +8505,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8282,6 +8542,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8318,6 +8579,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8357,6 +8619,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8388,6 +8651,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8417,6 +8681,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8446,6 +8711,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8475,6 +8741,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8504,6 +8771,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8533,6 +8801,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8562,6 +8831,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8591,6 +8861,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8620,6 +8891,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8652,6 +8924,7 @@
       "SupportBarrierInvocationPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressBarrierInvocation.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -8687,6 +8960,7 @@
       "SupportMetaCastOnDodgePlayer",
       "SupportInvisibleMetaGemSupport"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnDodgeRollSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -8720,6 +8994,7 @@
       "SupportMetaCastWhileChannellingPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/CastWhileChannellingSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -8753,6 +9028,7 @@
       "SupportMetaCastOnMeleeStunPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnMeleeStunSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8786,6 +9062,7 @@
     "grants_skills": [
       "SupportEnragedWarcryPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/EnragedWarcrySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8817,6 +9094,7 @@
       "LingeringIllusionPlayer",
       "LingeringIllusionSpawnPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkLingeringIllusion.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -8849,6 +9127,7 @@
     "grants_skills": [
       "GhostDancePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkGhostDance.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -8879,6 +9158,7 @@
     "grants_skills": [
       "BindSpectrePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchBindSpectre.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -8907,6 +9187,7 @@
     "grants_skills": [
       "DominatingAuraPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SpellDamageAura.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8940,6 +9221,7 @@
     "grants_skills": [
       "ShroudPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/AmbushIcon.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8972,6 +9254,7 @@
       "SummonMercenaryCompanionSupportPlayer",
       "CommandUnloadAmmoPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SummonMercCompanion.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -9006,6 +9289,7 @@
       "AncestralWarriorTotemPlayer",
       "SupportAncestralWarriorTotemPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteAncestralWarriorTotem.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -9041,6 +9325,7 @@
       "SummonMetaTotemSpellTotemPlayer",
       "SupportMetaTotemSpellTotemPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SpellMetaTotem.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -9072,6 +9357,7 @@
       "SummonMetaTotemBallistaPlayer",
       "SupportMetaTotemBallistaPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangedMetaTotem.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -9104,6 +9390,7 @@
     "grants_skills": [
       "ExplosiveGrenadePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/ExplosiveGrenade.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -9140,6 +9427,7 @@
     "grants_skills": [
       "FlashGrenadePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/FlashbangGrenade.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -9174,6 +9462,7 @@
     "grants_skills": [
       "OilGrenadePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/OilGrenade.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -9209,6 +9498,7 @@
     "grants_skills": [
       "ToxicGrenadePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/ToxicGrenade.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -9245,6 +9535,7 @@
     "grants_skills": [
       "ShockGrenadePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/ShockGrenade.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -9280,6 +9571,7 @@
     "grants_skills": [
       "PainOfferingPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchPainOffering.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -9313,6 +9605,7 @@
     "grants_skills": [
       "TempestFlurryPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkTempestFlurry.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -9349,6 +9642,7 @@
       "StaggeringPalmProjectilePlayer",
       "StaggeringPalmUnarmedProjectilePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkWindPalm.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -9386,6 +9680,7 @@
       "ChargedStaffPlayer",
       "ChargedStaffShockwavePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkChargedStaff.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -9420,6 +9715,7 @@
     "grants_skills": [
       "SiphoningStrikePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkSiphoningStrike.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -9455,6 +9751,7 @@
     "grants_skills": [
       "TempestBellPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkTempestBell.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -9488,6 +9785,7 @@
     "grants_skills": [
       "WeaponGrantedChaosboltPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/ChaosBoltWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -9521,6 +9819,7 @@
       "FrozenLocusPlayer",
       "FrozenLocusExplodePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkIceAmbush.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -9556,6 +9855,7 @@
     "grants_skills": [
       "BonestormPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchBoneStorm.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -9592,6 +9892,7 @@
     "grants_skills": [
       "BoneCagePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchBoneCage.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -9624,6 +9925,7 @@
     "grants_skills": [
       "SupportSpreadingFrostPlayer"
     ],
+    "icon_dds_file": null,
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -9654,6 +9956,7 @@
     "grants_skills": [
       "SupportNeuralOverloadPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/NeuralOverloadSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -9682,6 +9985,7 @@
     "grants_skills": [
       "SupportPinpointCriticalPlayer"
     ],
+    "icon_dds_file": null,
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -9712,6 +10016,7 @@
     "grants_skills": [
       "SupportPerpetualChargePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PerpetualChargeSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -9741,6 +10046,7 @@
     "grants_skills": [
       "SupportCorrosionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CorrosionSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -9772,6 +10078,7 @@
     "grants_skills": [
       "UnearthPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchUnearth.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -9806,6 +10113,7 @@
     "grants_skills": [
       "DetonatingArrowPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerDetonatingArrowSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -9841,6 +10149,7 @@
     "grants_skills": [
       "PoisonBurstArrowPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerPoisonBurstArrow.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -9873,6 +10182,7 @@
     "grants_skills": [
       "FireboltPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/FireballSkillStaff.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -9906,6 +10216,7 @@
     "grants_skills": [
       "ToxicGrowthPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerPoisonBloomSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -9940,6 +10251,7 @@
     "grants_skills": [
       "StormcallerArrowPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerShockingArrow.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -9974,6 +10286,7 @@
     "grants_skills": [
       "LightningRodPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerLightningRodRainSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10009,6 +10322,7 @@
     "grants_skills": [
       "SnipePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerSnipeShotArrow.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10042,6 +10356,7 @@
     "grants_skills": [
       "GasArrowPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerGasCloudSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10077,6 +10392,7 @@
     "grants_skills": [
       "SolarOrbPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressSolarOrb.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10112,6 +10428,7 @@
     "grants_skills": [
       "FireballPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressGreaterFireball.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10145,6 +10462,7 @@
     "grants_skills": [
       "ElectrocutingArrowPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerElectrocutingRodSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10178,6 +10496,7 @@
     "grants_skills": [
       "ColdSnapPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressColdSnap.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10211,6 +10530,7 @@
     "grants_skills": [
       "PerfectStrikePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BrutePerfectStrike.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -10245,6 +10565,7 @@
     "grants_skills": [
       "ShieldBlockPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteShieldBlock.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -10275,6 +10596,7 @@
     "grants_skills": [
       "ResonatingShieldPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteResonatingShield.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -10310,6 +10632,7 @@
     "grants_skills": [
       "ManaRemnantsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressEnergyRemnants.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10343,6 +10666,7 @@
       "MagmaBarrierPlayer",
       "MagmaSprayPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteMagmaBarrier.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -10378,6 +10702,7 @@
     "grants_skills": [
       "FreezingShardsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/FreezingShardsStaff.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10410,6 +10735,7 @@
     "grants_skills": [
       "VineArrowPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerPoisonVineArrowSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10442,6 +10768,7 @@
     "grants_skills": [
       "SummonRhoaMountPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SummonBeastRhoa.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10476,6 +10803,7 @@
       "SupportBurstingPlaguePlayer",
       "PlagueBurstPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BurstingPlagueSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10508,6 +10836,7 @@
     "grants_skills": [
       "CorpseCloudPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DecomposeSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10542,6 +10871,7 @@
     "grants_skills": [
       "SupportWallFortressPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/WallFortressSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10571,6 +10901,7 @@
     "grants_skills": [
       "SupportFrostfirePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FrostfireSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10603,6 +10934,7 @@
     "grants_skills": [
       "SupportStormfirePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/StormfireSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10634,6 +10966,7 @@
     "grants_skills": [
       "SupportIncreaseLimitPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IncreaseLimitSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10663,6 +10996,7 @@
     "grants_skills": [
       "SupportElectrocutePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ElectrocuteSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10693,6 +11027,7 @@
     "grants_skills": [
       "RagingSpiritsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchReservationRaginSpirits.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10727,6 +11062,7 @@
     "grants_skills": [
       "SupportEnergyBarrierPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/EnergyBarrierSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10757,6 +11093,7 @@
       "SupportKnockbackWavePlayer",
       "KnockbackWavePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/KnockbackWaveSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10789,6 +11126,7 @@
     "grants_skills": [
       "SupportBitingFrostPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BitingFrostSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10821,6 +11159,7 @@
       "SupportElementalDischargePlayer",
       "TriggeredElementalDischargePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ElementalDischargeSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10856,6 +11195,7 @@
     "grants_skills": [
       "SupportHourglassPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/HourglassSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10886,6 +11226,7 @@
       "SupportFieryDeathPlayer",
       "TriggeredFieryDeathPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FieryDeathSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10916,6 +11257,7 @@
     "grants_skills": [
       "SandstormSwipePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SandBladeStorm.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10946,6 +11288,7 @@
     "grants_skills": [
       "DestructiveLinkSkeletonBombadierMinion"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchArsonistSkeleton.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10976,6 +11319,7 @@
     "grants_skills": [
       "RemoteSpearMinePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BlastRain.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11005,6 +11349,7 @@
     "grants_skills": [
       "SpearWindVortexPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Tornado.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11036,6 +11381,7 @@
       "SpearInfusingStrikePlayer",
       "InfusedSpearMinePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/ElementalStrike.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11070,6 +11416,7 @@
     "grants_skills": [
       "SpearLightningWarpPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressLightningWarp.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11103,6 +11450,7 @@
       "WindDancerPlayer",
       "TriggeredWindDancerPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerWindDancerSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11135,6 +11483,7 @@
     "grants_skills": [
       "SupportDeadlyHeraldsPlayer"
     ],
+    "icon_dds_file": null,
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11163,6 +11512,7 @@
     "grants_skills": [
       "SupportBuffedHeraldPlayer"
     ],
+    "icon_dds_file": null,
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11194,6 +11544,7 @@
       "SupportManaFlarePlayer",
       "TriggeredManaFlarePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ManaFlareSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11227,6 +11578,7 @@
     "grants_skills": [
       "SupportLockdownPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LockdownSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11257,6 +11609,7 @@
     "grants_skills": [
       "SupportOverpowerPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/OverpowerSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -11286,6 +11639,7 @@
     "grants_skills": [
       "SupportMobilityPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MobilitySupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11315,6 +11669,7 @@
     "grants_skills": [
       "SupportPinPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PinSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11345,6 +11700,7 @@
     "grants_skills": [
       "SupportAmbushPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AmbushSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11375,6 +11731,7 @@
     "grants_skills": [
       "ProfaneRitualPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchProfaneRitual.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11408,6 +11765,7 @@
     "grants_skills": [
       "SoulOfferingPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchPowerOffering.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11441,6 +11799,7 @@
       "DarkEffigyPlayer",
       "DarkEffigyProjectilePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchDarkEffigy.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11476,6 +11835,7 @@
     "grants_skills": [
       "SupportManaFlaskPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ManaFlaskSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11505,6 +11865,7 @@
     "grants_skills": [
       "SupportLifeFlaskPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LifeFlaskSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11532,6 +11893,7 @@
     "grants_skills": [
       "WeaponGrantedSummonSkeletalWarriorsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchWarriorSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 75,
@@ -11564,6 +11926,7 @@
     "grants_skills": [
       "SupportMinionInstabilityPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MinionInstabilitySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11595,6 +11958,7 @@
     "grants_skills": [
       "SupportEnduranceChargeOnArmourBreak"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BreakEndurance.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -11624,6 +11988,7 @@
     "grants_skills": [
       "SupportCurseEffectPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CurseEffectSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11654,6 +12019,7 @@
     "grants_skills": [
       "SupportCorpseConservationPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CorpseConservationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11683,6 +12049,7 @@
     "grants_skills": [
       "SupportDecayingHexPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DecayingHexSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11714,6 +12081,7 @@
     "grants_skills": [
       "SupportFocusedCursePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FocusedHexSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11744,6 +12112,7 @@
     "grants_skills": [
       "SupportRitualisticCursePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/RitualisticCurseSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11774,6 +12143,7 @@
     "grants_skills": [
       "SupportMinionPactPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MinionPactSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11804,6 +12174,7 @@
     "grants_skills": [
       "SupportLastGaspPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LastGaspSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11836,6 +12207,7 @@
     "grants_skills": [
       "SupportLifeOnCullPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LifeOnCull.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11865,6 +12237,7 @@
     "grants_skills": [
       "SupportManaOnCullPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ManaOnCull.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11894,6 +12267,7 @@
     "grants_skills": [
       "GrimFeastPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchGrimFeast.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11926,6 +12300,7 @@
     "grants_skills": [
       "SupportInnervatePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/Innervate.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11960,6 +12335,7 @@
       "SupportMetaCastOnMinionDeathPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnMinionDeath.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11994,6 +12370,7 @@
     "grants_skills": [
       "SupportMultiplePoisonPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MultiplePoisonSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -12024,6 +12401,7 @@
     "grants_skills": [
       "SupportMultipleChargesPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MultipleChargesSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -12053,6 +12431,7 @@
     "grants_skills": [
       "SupportEmpoweredDamagePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/EmpoweredDamageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -12082,6 +12461,7 @@
     "grants_skills": [
       "SupportEmpoweredCullPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/EmpoweredCullSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -12111,6 +12491,7 @@
     "grants_skills": [
       "ScavengedPlatingPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteScavengedPlating.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -12142,6 +12523,7 @@
     "grants_skills": [
       "SpinningInfernoPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/FlamesOfJudgement.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -12174,6 +12556,7 @@
     "grants_skills": [
       "ManaDrainPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/ManaDrainWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12202,6 +12585,7 @@
     "grants_skills": [
       "BoneBlastPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BoneBlastWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12236,6 +12620,7 @@
       "BlinkReservationPlayer",
       "BlinkPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressBlinkReservation.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12268,6 +12653,7 @@
     "grants_skills": [
       "MoltenBlastPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteMoltenBlast.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -12299,6 +12685,7 @@
     "grants_skills": [
       "MalicePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MaliceWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 75,
@@ -12332,6 +12719,7 @@
       "HydraPlayer",
       "SupportHydraPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/AncestorTotemSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12366,6 +12754,7 @@
     "grants_skills": [
       "HammerOfTheGodsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteHammerOfTheGods.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -12398,6 +12787,7 @@
     "grants_skills": [
       "LivingBombPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/LivingBombWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12431,6 +12821,7 @@
     "grants_skills": [
       "StampedePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteStampede.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -12466,6 +12857,7 @@
     "grants_skills": [
       "ShieldWallPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteShieldWall.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -12498,6 +12890,7 @@
       "ShieldingCryPlayer",
       "ShieldingCryShockwavePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WarCryIntimidating.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -12534,6 +12927,7 @@
     "grants_skills": [
       "BlazingClusterPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressBlazingCluster.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12569,6 +12963,7 @@
       "HighVelocityRoundsAmmoPlayer",
       "HighVelocityRoundsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/PowerShotPhysical.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -12604,6 +12999,7 @@
       "FragmentationRoundsAmmoPlayer",
       "FragmentationRoundsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BurstShotPhysical.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -12638,6 +13034,7 @@
       "SiegeCascadeAmmoPlayer",
       "SiegeCascadePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SiegeCascadeIncendiary.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -12675,6 +13072,7 @@
       "ArmourPiercingBoltsAmmoPlayer",
       "ArmourPiercingBoltsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RapidShotPhysical.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -12709,6 +13107,7 @@
       "ExplosiveShotAmmoPlayer",
       "ExplosiveShotPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/PowerShotIncendiary.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -12745,6 +13144,7 @@
       "IncendiaryShotAmmoPlayer",
       "IncendiaryShotPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BurstShotIncendiary.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -12780,6 +13180,7 @@
       "RapidShotAmmoPlayer",
       "RapidShotPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RapidShotIncendiary.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -12814,6 +13215,7 @@
       "GlacialBoltAmmoPlayer",
       "GlacialBoltPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/PowerShotPermafrost.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -12850,6 +13252,7 @@
       "PermafrostBoltsAmmoPlayer",
       "PermafrostBoltsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BurstShotPermafrost.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -12885,6 +13288,7 @@
       "HailstormRoundsAmmoPlayer",
       "HailstormRoundsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SiegeCascadePermafrost.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -12921,6 +13325,7 @@
       "IceShardsAmmoPlayer",
       "IceShardsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RapidShotPermafrost.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -12957,6 +13362,7 @@
       "PlasmaBlastAmmoPlayer",
       "PlasmaBlastPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/PowerShotStormblast.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -12993,6 +13399,7 @@
       "GalvanicShardsAmmoPlayer",
       "GalvanicShardsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BurstShotStormblast.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -13028,6 +13435,7 @@
       "StormblastBoltsAmmoPlayer",
       "StormblastBoltsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SiegeCascadeStormblast.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -13064,6 +13472,7 @@
       "ShockburstRoundsAmmoPlayer",
       "ShockburstRoundsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RapidShotStormblast.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -13099,6 +13508,7 @@
     "grants_skills": [
       "SupportRagingCryPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/RagingCrySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13129,6 +13539,7 @@
     "grants_skills": [
       "SupportIncreasedArmourBreakPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IncreasedArmourBreakSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13159,6 +13570,7 @@
     "grants_skills": [
       "SupportRageforgedPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/RageforgedSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13186,6 +13598,7 @@
     "grants_skills": [
       "MeleeUnarmedPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/UnarmedDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13217,6 +13630,7 @@
     "grants_skills": [
       "MeleeQuarterstaffPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/QuarterstaffDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13248,6 +13662,7 @@
     "grants_skills": [
       "MeleeFlailPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/FlailDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13279,6 +13694,7 @@
     "grants_skills": [
       "Melee1HSwordPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/OneHandSwordDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13310,6 +13726,7 @@
     "grants_skills": [
       "MeleeSwordSwordPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DualWieldSwordDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13341,6 +13758,7 @@
     "grants_skills": [
       "Melee2HSwordPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/TwoHandSwordDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13372,6 +13790,7 @@
     "grants_skills": [
       "Melee1HAxePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/OneHandAxeDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13403,6 +13822,7 @@
     "grants_skills": [
       "MeleeAxeAxePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DualWieldAxeDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13434,6 +13854,7 @@
     "grants_skills": [
       "Melee2HAxePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/TwoHandAxeDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13465,6 +13886,7 @@
     "grants_skills": [
       "Melee1HMacePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/OneHandMaceDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13496,6 +13918,7 @@
     "grants_skills": [
       "MeleeMaceMacePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DualWieldMaceDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13527,6 +13950,7 @@
     "grants_skills": [
       "Melee2HMacePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/TwoHandMaceDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13558,6 +13982,7 @@
     "grants_skills": [
       "MeleeClawPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/OneHandClawDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13589,6 +14014,7 @@
     "grants_skills": [
       "MeleeClawClawPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DualWieldClawDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13620,6 +14046,7 @@
     "grants_skills": [
       "MeleeDaggerPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/OneHandDaggerDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13651,6 +14078,7 @@
     "grants_skills": [
       "MeleeDaggerDaggerPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/TwoHandDaggerDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13682,6 +14110,7 @@
     "grants_skills": [
       "MeleeSpearPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SpearDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13713,6 +14142,7 @@
     "grants_skills": [
       "MeleeBowPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BowDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13742,6 +14172,7 @@
     "grants_skills": [
       "MeleeCrossbowPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/PowerShot.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13772,6 +14203,7 @@
     "grants_skills": [
       "PlaytestAttack"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/iconbasicattack.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13803,6 +14235,7 @@
     "grants_skills": [
       "PlaytestSlam"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteLeapSlam.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13835,6 +14268,7 @@
     "grants_skills": [
       "PlaytestSpell"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/FireballSkillStaff.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13866,6 +14300,7 @@
     "grants_skills": [
       "LifeRemnantsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BloodChannel.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13895,6 +14330,7 @@
     "grants_skills": [
       "ExplosiveConcoctionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerBrewConcoctionFireSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13927,6 +14363,7 @@
     "grants_skills": [
       "FulminatingConcoctionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerBrewConcoctionLightningSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13959,6 +14396,7 @@
     "grants_skills": [
       "ShatteringConcoctionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerBrewConcoctionColdSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13991,6 +14429,7 @@
     "grants_skills": [
       "PoisonousConcoctionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerBrewConcoctionPoisonSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14022,6 +14461,7 @@
     "grants_skills": [
       "BleedingConcoctionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerBrewConcoctionBleedSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14053,6 +14493,7 @@
     "grants_skills": [
       "MeditatePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkInvokerMeditate.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14082,6 +14523,7 @@
     "grants_skills": [
       "ElementalStormPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressElementalStorm.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14117,6 +14559,7 @@
     "grants_skills": [
       "UnboundAvatarPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkInvokerUnboundAvatar.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14149,6 +14592,7 @@
     "grants_skills": [
       "SummonInfernalHoundPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchSummonInfernalFamiliar.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14179,6 +14623,7 @@
     "grants_skills": [
       "TemporalRiftPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressTemporalistTemporalRift.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14209,6 +14654,7 @@
     "grants_skills": [
       "TimeFreezePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressTemporalistTimeStop.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14239,6 +14685,7 @@
     "grants_skills": [
       "TimeSnapPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressTemporalistReloadCooldown.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14267,6 +14714,7 @@
     "grants_skills": [
       "EncaseInJadePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteWarbringerEncasedJade.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14299,6 +14747,7 @@
     "grants_skills": [
       "DemonFormPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchTransformDemon.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14329,6 +14778,7 @@
     "grants_skills": [
       "SorceryWardPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchunterSpellAegis.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14362,6 +14812,7 @@
     "grants_skills": [
       "IntoTheBreachPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkBreachWalk.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14391,6 +14842,7 @@
     "grants_skills": [
       "AncestralSpiritsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BruteWarbringerDefenders.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14424,6 +14876,7 @@
       "SupportArmourExplosionPlayer",
       "ArmourExplosionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ArmourExplosionSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14460,6 +14913,7 @@
       "SupportStompingGroundPlayer",
       "StompingGroundShockwavePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/StompingGroundSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14493,6 +14947,7 @@
     "grants_skills": [
       "SupportCrescendoPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ExtendedCombo.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -14525,6 +14980,7 @@
     "grants_skills": [
       "SupportFireExposurePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FireExposureSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14556,6 +15012,7 @@
     "grants_skills": [
       "SupportLightningExposurePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LightningExposureSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -14587,6 +15044,7 @@
     "grants_skills": [
       "SupportColdExposurePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ColdExposureSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -14619,6 +15077,7 @@
     "grants_skills": [
       "SupportDeadlyPoisonPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DeadlyPoisonSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -14649,6 +15108,7 @@
     "grants_skills": [
       "SupportDeepCutsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DeepCutsSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14679,6 +15139,7 @@
     "grants_skills": [
       "SupportCorruptingCryPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CorruptingCrySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14711,6 +15172,7 @@
     "grants_skills": [
       "SupportWindowOfOpportunityPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/WindowOfOpportunitySupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -14741,6 +15203,7 @@
     "grants_skills": [
       "SupportFireMasteryPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FireMasterySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -14771,6 +15234,7 @@
     "grants_skills": [
       "SupportColdMasteryPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ColdMasterySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -14801,6 +15265,7 @@
     "grants_skills": [
       "SupportLightningMasteryPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LightningMasterySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -14831,6 +15296,7 @@
     "grants_skills": [
       "SupportChaosMasteryPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ChaosMasterySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -14861,6 +15327,7 @@
     "grants_skills": [
       "SupportPhysicalMasteryPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PhysicalMasterySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -14891,6 +15358,7 @@
     "grants_skills": [
       "SupportMinionMasteryPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PhysicalMasterySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -14921,6 +15389,7 @@
     "grants_skills": [
       "ShockchainArrowPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerShockchainSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -14956,6 +15425,7 @@
     "grants_skills": [
       "VaultingImpactPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkVaultingImpact.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -14990,6 +15460,7 @@
     "grants_skills": [
       "StormWavePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkStormWave.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -15023,6 +15494,7 @@
     "grants_skills": [
       "MantraOfDestructionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkMantraofDestruction.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -15055,6 +15527,7 @@
     "grants_skills": [
       "SupportSwiftAfflictionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/SwiftAfflictionSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15085,6 +15558,7 @@
     "grants_skills": [
       "SupportChaoticAssassinationPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IntenseAgonySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15116,6 +15590,7 @@
     "grants_skills": [
       "SupportDrainedAilmentPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DrainedAilmentSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15146,6 +15621,7 @@
     "grants_skills": [
       "SupportChaoticFreezePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ChaoticFreezeSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15177,6 +15653,7 @@
     "grants_skills": [
       "SupportHinderPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/HinderSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15206,6 +15683,7 @@
     "grants_skills": [
       "SupportFusilladePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FusilladeSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15236,6 +15714,7 @@
     "grants_skills": [
       "SupportComboFinisherPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ComboFinisherSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15267,6 +15746,7 @@
     "grants_skills": [
       "SupportEncumberancePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/EncumberanceSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15298,6 +15778,7 @@
     "grants_skills": [
       "SupportPrecisionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PrecisionSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15329,6 +15810,7 @@
     "grants_skills": [
       "SupportClarityPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ClaritySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15360,6 +15842,7 @@
     "grants_skills": [
       "SupportVitalityPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/VitalitySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -15391,6 +15874,7 @@
     "grants_skills": [
       "SupportHerbalismPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/HerbalismSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -15422,6 +15906,7 @@
     "grants_skills": [
       "SupportCannibalismPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CannibalismSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -15451,6 +15936,7 @@
     "grants_skills": [
       "CorpsewadeCorpseCloudPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DecomposeSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -15484,6 +15970,7 @@
       "SupportSoulbreakerPlayer",
       "TriggeredSoulbreakerPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/SoulbreakerSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15516,6 +16003,7 @@
     "grants_skills": [
       "SupportRupturePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/RuptureSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -15546,6 +16034,7 @@
     "grants_skills": [
       "SupportCullingStrikePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CullingStrikeSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15576,6 +16065,7 @@
     "grants_skills": [
       "SupportSpellCascadePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/SpellCascadeSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15605,6 +16095,7 @@
     "grants_skills": [
       "SupportArmourBreakPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ArmourBreakSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -15634,6 +16125,7 @@
     "grants_skills": [
       "SupportFarCombatPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FarCombatSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15664,6 +16156,7 @@
     "grants_skills": [
       "SupportDazingPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DazingSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15695,6 +16188,7 @@
     "grants_skills": [
       "SupportDazedBreakPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DazedBreakSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15725,6 +16219,7 @@
     "grants_skills": [
       "SupportDazingCryPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DazingCrySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -15755,6 +16250,7 @@
     "grants_skills": [
       "SupportCursedGroundPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CursedGroundSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15784,6 +16280,7 @@
     "grants_skills": [
       "SupportWeaponElementalDamagePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/WeaponElementalDamageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -15814,6 +16311,7 @@
     "grants_skills": [
       "SupportCooldownReductionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CooldownReductionSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15841,6 +16339,7 @@
     "grants_skills": [
       "ElementalExpressionTriggeredPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkInvokerWildStrike.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -15878,6 +16377,7 @@
     "grants_skills": [
       "IceShotPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerIceShot.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15911,6 +16411,7 @@
       "WarBannerReservationPlayer",
       "WarBannerPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WarBannerSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -15946,6 +16447,7 @@
       "DefianceBannerReservationPlayer",
       "DefianceBannerPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DefianceBannerSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -15982,6 +16484,7 @@
       "DreadBannerReservationPlayer",
       "DreadBannerPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/DreadBannerSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -16017,6 +16520,7 @@
       "FreezingMarkPlayer",
       "TriggeredFreezingMarkNovaPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/FreezingMarkSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -16054,6 +16558,7 @@
       "VoltaicMarkPlayer",
       "TriggeredVoltaicMarkNovaPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/ShockingMarkSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -16091,6 +16596,7 @@
       "HandOfChayulaPlayer",
       "SupportHandOfChayulaPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkHandOfChayula.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -16126,6 +16632,7 @@
     "grants_skills": [
       "TimeOfNeedPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/TimeOfNeedSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16160,6 +16667,7 @@
       "SupportElementalInvocationPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/ElementalInvocationSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -16197,6 +16705,7 @@
     "grants_skills": [
       "AttritionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/AttritionSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -16228,6 +16737,7 @@
     "grants_skills": [
       "ElementalConfluxPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/ElementalConfluxSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -16263,6 +16773,7 @@
     "grants_skills": [
       "EmergencyReloadPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MercEmergencyReload.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -16294,6 +16805,7 @@
     "grants_skills": [
       "SupportBloodFountainPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FontOfBloodSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16324,6 +16836,7 @@
     "grants_skills": [
       "SupportManaFountainPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ManaFountainSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -16354,6 +16867,7 @@
     "grants_skills": [
       "SupportRageFountainPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FontOfRageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16384,6 +16898,7 @@
     "grants_skills": [
       "SupportAftershockChancePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AftershockSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16417,6 +16932,7 @@
       "ClusterGrenadePlayer",
       "ClusterGrenadeMiniPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MercClusterGrenade.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -16452,6 +16968,7 @@
     "grants_skills": [
       "TornadoShotPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerTornadoShotSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -16484,6 +17001,7 @@
     "grants_skills": [
       "BlinkSandPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressBlinkReservation.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16514,6 +17032,7 @@
     "grants_skills": [
       "ChargeInfusionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/ChargeMasteryDeath.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -16545,6 +17064,7 @@
     "grants_skills": [
       "SupportHolyDescentPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/HolyDescentSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16575,6 +17095,7 @@
       "SupportBurningRunesPlayer",
       "TriggeredBurningRunesPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BurningRunesSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -16607,6 +17128,7 @@
     "grants_skills": [
       "ShardScavengerPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MercShardDespoiler.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -16642,6 +17164,7 @@
     "grants_skills": [
       "SupportDoubleBarrelPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DoubleBarrelSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16671,6 +17194,7 @@
     "grants_skills": [
       "SupportAutoReloadPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AutoReloadSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16700,6 +17224,7 @@
     "grants_skills": [
       "SupportAmmoConservationPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ChanceToNotConsumeAmmoSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -16729,6 +17254,7 @@
     "grants_skills": [
       "SupportNimbleReloadPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ReloadSpeedSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -16758,6 +17284,7 @@
     "grants_skills": [
       "SupportFreshClipPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DamagePerBoltReloadedRecentlySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16785,6 +17312,7 @@
     "grants_skills": [
       "SupportSacrificialLambPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/SacrificalLambSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -16816,6 +17344,7 @@
     "grants_skills": [
       "OverwhelmingPresencePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/OverwhelmingPressureSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16847,6 +17376,7 @@
     "grants_skills": [
       "AlchemistsBoonPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/AlchemistsBoonSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -16881,6 +17411,7 @@
       "SupportReapersInvocationPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MeleeInvocationSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -16914,6 +17445,7 @@
     "grants_skills": [
       "SacrificePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/HarvesterSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -16946,6 +17478,7 @@
     "grants_skills": [
       "ArchmagePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/ArchmageSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -16978,6 +17511,7 @@
     "grants_skills": [
       "MagneticSalvoPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerMagneticSalvo.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17011,6 +17545,7 @@
     "grants_skills": [
       "FreezingSalvoPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerFreezingSalvoSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17042,6 +17577,7 @@
     "grants_skills": [
       "TriggeredGasCloudPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerGasCloudSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17071,6 +17607,7 @@
     "grants_skills": [
       "TriggeredDetonationPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerDetonatingArrowSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17101,6 +17638,7 @@
     "grants_skills": [
       "BerserkPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/BeserkSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17132,6 +17670,7 @@
     "grants_skills": [
       "HeraldOfPlaguePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/HeraldOfAgonySkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17163,6 +17702,7 @@
     "grants_skills": [
       "HeraldOfBloodPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/iconbasicattack.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -17195,6 +17735,7 @@
     "grants_skills": [
       "WitheringPresencePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/WitchWitheringPresence.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -17228,6 +17769,7 @@
     "grants_skills": [
       "CombatFrenzyPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/RangerCombatFrenzySkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17259,6 +17801,7 @@
       "SupportMetaCastOnBlockPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnMeleeBlockSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -17292,6 +17835,7 @@
     "grants_skills": [
       "GatheringStormPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/MonkGatheringStorm.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -17328,6 +17872,7 @@
     "grants_skills": [
       "SupportUpheavalPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/UpheavalSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17359,6 +17904,7 @@
     "grants_skills": [
       "SupportGroundEffectDurationPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/GroundEffectDurationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17388,6 +17934,7 @@
     "grants_skills": [
       "SupportRicochetPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/TerrainChainSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17418,6 +17965,7 @@
     "grants_skills": [
       "SupportAncestralUrgencyPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/TotemPlacementSpeedSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17448,6 +17996,7 @@
     "grants_skills": [
       "SupportLongFusePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LongFuseSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17478,6 +18027,7 @@
     "grants_skills": [
       "SupportPayloadPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PayloadSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17508,6 +18058,7 @@
     "grants_skills": [
       "SupportStripAwayPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/StripAwaySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -17538,6 +18089,7 @@
     "grants_skills": [
       "SupportIronwoodPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IronwoodSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17568,6 +18120,7 @@
     "grants_skills": [
       "SupportConsideredCastingPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ConsideredCastingSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -17598,6 +18151,7 @@
     "grants_skills": [
       "SupportWildshardsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/WildshardsSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -17629,6 +18183,7 @@
     "grants_skills": [
       "SupportIciclePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IceCrystalLessLifeSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -17658,6 +18213,7 @@
     "grants_skills": [
       "SupportGlacierPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IceCrystalMoreLifeSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -17687,6 +18243,7 @@
     "grants_skills": [
       "SupportHeftPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/HeftSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17716,6 +18273,7 @@
     "grants_skills": [
       "SupportTempestuousTempoPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/TempestTempoSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -17745,6 +18303,7 @@
     "grants_skills": [
       "SupportExtractionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ExtractionSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -17774,6 +18333,7 @@
     "grants_skills": [
       "SupportAstralProjectionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AstralProjectionSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -17803,6 +18363,7 @@
     "grants_skills": [
       "SupportPracticedComboPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PracticedComboSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17835,6 +18396,7 @@
     "grants_skills": [
       "SupportLeveragePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LeverageSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17864,6 +18426,7 @@
     "grants_skills": [
       "SupportCulminationPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CulminationSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17895,6 +18458,7 @@
     "grants_skills": [
       "SupportPotentialPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PotentialSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -17924,6 +18488,7 @@
     "grants_skills": [
       "SupportExpansePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ExecrateSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -17954,6 +18519,7 @@
     "grants_skills": [
       "SupportExcisePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ExciseSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -17983,6 +18549,7 @@
     "grants_skills": [
       "SupportExecratePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ExpanseSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18012,6 +18579,7 @@
     "grants_skills": [
       "SupportEnergyRetentionPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/EnergyRetentionSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18041,6 +18609,7 @@
     "grants_skills": [
       "SupportFerocityPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FerocitySupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -18070,6 +18639,7 @@
     "grants_skills": [
       "SupportAblationPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AblationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18099,6 +18669,7 @@
     "grants_skills": [
       "SupportDanseMacabrePlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DanseMacabreSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18128,6 +18699,7 @@
     "grants_skills": [
       "SupportCapacitorPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CapacitorSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18157,6 +18729,7 @@
     "grants_skills": [
       "SupportImpetusPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ImpetusSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18186,6 +18759,7 @@
     "grants_skills": [
       "SupportBiddingPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BiddingSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18215,6 +18789,7 @@
     "grants_skills": [
       "SupportTremorsPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/UnstableEarthSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -18245,6 +18820,7 @@
     "grants_skills": [
       "UniqueDuskVigilTriggeredBlazingClusterPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressBlazingCluster.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18277,6 +18853,7 @@
     "grants_skills": [
       "UniqueEarthboundTriggeredSparkPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressSpark.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18308,6 +18885,7 @@
     "grants_skills": [
       "SupportExpandingGroundPlayer"
     ],
+    "icon_dds_file": "",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18335,6 +18913,7 @@
     "grants_skills": [
       "UniqueBreachLightningBoltPlayer"
     ],
+    "icon_dds_file": "Art/2DArt/SkillIcons/GreaterLightningBoltSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,

--- a/RePoE/data/poe2/skill_gems.json
+++ b/RePoE/data/poe2/skill_gems.json
@@ -14,7 +14,7 @@
     "grants_skills": [
       "IceNovaPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressIceNova.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressIceNova.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -48,7 +48,7 @@
     "grants_skills": [
       "LeapSlamPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteLeapSlam.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteLeapSlam.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -84,7 +84,7 @@
     "grants_skills": [
       "ShieldChargePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteShieldCharge.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteShieldCharge.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -120,7 +120,7 @@
     "grants_skills": [
       "DetonateDeadPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchDetonateDead.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchDetonateDead.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -153,7 +153,7 @@
     "grants_skills": [
       "VolatileDeadPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/VolatileDeadWeaponSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/VolatileDeadWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -186,7 +186,7 @@
     "grants_skills": [
       "SupportAddedFireDamagePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AddedFireDamageSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/AddedFireDamageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -218,7 +218,7 @@
     "grants_skills": [
       "SupportFasterAttackPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FasterAttack.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FasterAttack.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -249,7 +249,7 @@
     "grants_skills": [
       "SupportMultipleProjectilesPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MultipleProjectilesSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/MultipleProjectilesSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -280,7 +280,7 @@
     "grants_skills": [
       "SupportFasterProjectilesPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FasterProjectilesSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FasterProjectilesSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -311,7 +311,7 @@
     "grants_skills": [
       "SupportAddedColdDamagePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AddedColdDamageSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/AddedColdDamageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -343,7 +343,7 @@
     "grants_skills": [
       "SupportAdditionalAccuracyPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AdditionalAccuracy.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/AdditionalAccuracy.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -374,7 +374,7 @@
     "grants_skills": [
       "SupportIncreasedAreaOfEffectPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IncreasedAreaOfEffectSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/IncreasedAreaOfEffectSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -405,7 +405,7 @@
     "grants_skills": [
       "SupportAddedLightningDamagePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AddedLightningDamageSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/AddedLightningDamageSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -437,7 +437,7 @@
     "grants_skills": [
       "RaiseZombiePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchRaiseZombie.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchRaiseZombie.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -470,7 +470,7 @@
     "grants_skills": [
       "SupportInspirationPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/Inspiration.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/Inspiration.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -500,7 +500,7 @@
     "grants_skills": [
       "SupportIncreasedCriticalDamagePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IncreasedCritDamageSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/IncreasedCritDamageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -531,7 +531,7 @@
     "grants_skills": [
       "SupportKnockbackPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/KnockbackSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/KnockbackSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -561,7 +561,7 @@
     "grants_skills": [
       "SupportLifeLeechPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LifeLeechSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/LifeLeechSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -593,7 +593,7 @@
     "grants_skills": [
       "SupportManaLeechPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ManaLeechSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ManaLeechSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -625,7 +625,7 @@
     "grants_skills": [
       "SupportAddedChaosDamagePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AddedChaosDamageSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/AddedChaosDamageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -657,7 +657,7 @@
     "grants_skills": [
       "FlickerStrikePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkFlickerStrikeTeleport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkFlickerStrikeTeleport.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -691,7 +691,7 @@
     "grants_skills": [
       "SparkPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressSpark.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressSpark.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -723,7 +723,7 @@
     "grants_skills": [
       "IceSpearPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/HuntressIceSpear.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/HuntressIceSpear.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -757,7 +757,7 @@
     "grants_skills": [
       "SupportPiercePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PierceSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/PierceSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -786,7 +786,7 @@
     "grants_skills": [
       "SummonSpectrePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchSpectre.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchSpectre.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -818,7 +818,7 @@
     "grants_skills": [
       "FrostWallPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressFrostWall.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressFrostWall.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -850,7 +850,7 @@
     "grants_skills": [
       "ShockNovaPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/ShockNova.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/ShockNova.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -884,7 +884,7 @@
     "grants_skills": [
       "SupportMeleePhysicalDamagePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MeleePhysicalDamageSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/MeleePhysicalDamageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -917,7 +917,7 @@
     "grants_skills": [
       "SupportFasterCastPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FasterCastSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FasterCastSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -948,7 +948,7 @@
     "grants_skills": [
       "TemporalChainsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/temporalchains.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/temporalchains.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -982,7 +982,7 @@
     "grants_skills": [
       "EnfeeblePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/enfeeble.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/enfeeble.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1016,7 +1016,7 @@
     "grants_skills": [
       "SnipersMarkPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/projectileweakness.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/projectileweakness.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -1049,7 +1049,7 @@
     "grants_skills": [
       "DespairPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Despair.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/Despair.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1084,7 +1084,7 @@
     "grants_skills": [
       "LightningWarpPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressLightningWarp.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressLightningWarp.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1118,7 +1118,7 @@
     "grants_skills": [
       "ArmourBreakerPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteHeavyStrike.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteHeavyStrike.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -1153,7 +1153,7 @@
     "grants_skills": [
       "RainOfArrowsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerRainOfArrowsSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerRainOfArrowsSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -1187,7 +1187,7 @@
     "grants_skills": [
       "SupportConcentratedEffectPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ConcentratedEffectSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ConcentratedEffectSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1218,7 +1218,7 @@
     "grants_skills": [
       "SupportBloodlustPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BloodlustSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/BloodlustSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -1251,7 +1251,7 @@
     "grants_skills": [
       "FirestormPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchFirestorm.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchFirestorm.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1287,7 +1287,7 @@
     "grants_skills": [
       "FallingThunderPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkLightningStrike.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkLightningStrike.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -1321,7 +1321,7 @@
     "grants_skills": [
       "PowerSiphonPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/PowerSiphonWeaponSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/PowerSiphonWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1353,7 +1353,7 @@
     "grants_skills": [
       "LightningArrowPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerLightningArrow.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerLightningArrow.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -1386,7 +1386,7 @@
     "grants_skills": [
       "DisciplinePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DisciplineWeaponSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DisciplineWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 75,
@@ -1420,7 +1420,7 @@
       "ShockwaveTotemPlayer",
       "ShockwaveTotemQuakePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteShockwaveTotem.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteShockwaveTotem.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -1458,7 +1458,7 @@
     "grants_skills": [
       "SupportBlindPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BlindSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/BlindSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -1488,7 +1488,7 @@
     "grants_skills": [
       "ArcPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressArc.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressArc.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1521,7 +1521,7 @@
     "grants_skills": [
       "ArcticArmourPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressArcticArmour.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressArcticArmour.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1556,7 +1556,7 @@
     "grants_skills": [
       "SupportFirePenetrationPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FirePenetrationSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FirePenetrationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -1587,7 +1587,7 @@
     "grants_skills": [
       "SupportColdPenetrationPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ColdPenetrationSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ColdPenetrationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1618,7 +1618,7 @@
     "grants_skills": [
       "SupportLightningPenetrationPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LightningPenetrationSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/LightningPenetrationSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -1649,7 +1649,7 @@
     "grants_skills": [
       "SupportChainPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ChainSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ChainSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -1681,7 +1681,7 @@
     "grants_skills": [
       "SupportForkPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ForkSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ForkSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -1712,7 +1712,7 @@
     "grants_skills": [
       "FlammabilityPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Flammability.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/Flammability.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1747,7 +1747,7 @@
     "grants_skills": [
       "HypothermiaPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Frostbite.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/Frostbite.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1782,7 +1782,7 @@
     "grants_skills": [
       "ConductivityPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Conductivity.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/Conductivity.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1817,7 +1817,7 @@
     "grants_skills": [
       "IncineratePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressIncinerate.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressIncinerate.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1853,7 +1853,7 @@
     "grants_skills": [
       "SupportSpellEchoPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/SpellEchoSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/SpellEchoSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1885,7 +1885,7 @@
     "grants_skills": [
       "SupportElementalArmyPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ElementalArmySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ElementalArmySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -1916,7 +1916,7 @@
     "grants_skills": [
       "SupportSlowerProjectilesPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/SlowerProjectilesSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/SlowerProjectilesSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -1945,7 +1945,7 @@
     "grants_skills": [
       "PurityOfFirePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/PurityofFireWeaponSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/PurityofFireWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 75,
@@ -1977,7 +1977,7 @@
     "grants_skills": [
       "PurityOfIcePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/PurityofColdWeaponSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/PurityofColdWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 75,
@@ -2009,7 +2009,7 @@
     "grants_skills": [
       "PurityOfLightningPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/PurityofLightningWeaponSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/PurityofLightningWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 75,
@@ -2043,7 +2043,7 @@
     "grants_skills": [
       "FlameblastPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressFlameblast.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressFlameblast.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2078,7 +2078,7 @@
     "grants_skills": [
       "BarragePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerBarrageSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerBarrageSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -2111,7 +2111,7 @@
     "grants_skills": [
       "BallLightningPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressBallLightning.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressBallLightning.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2146,7 +2146,7 @@
     "grants_skills": [
       "BoneOfferingPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchBoneOffering.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchBoneOffering.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2182,7 +2182,7 @@
     "grants_skills": [
       "HeraldOfAshPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/HeraldOfAshSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/HeraldOfAshSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -2218,7 +2218,7 @@
     "grants_skills": [
       "HeraldOfIcePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/HeraldOfIceSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/HeraldOfIceSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -2257,7 +2257,7 @@
     "grants_skills": [
       "HeraldOfThunderPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/HeraldOfThunderSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/HeraldOfThunderSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -2295,7 +2295,7 @@
       "BlasphemyPlayer",
       "SupportBlasphemyPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchBlasphemy.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchBlasphemy.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2331,7 +2331,7 @@
       "InfernalCryPlayer",
       "InfernalCryCorpseExplosionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteInfernalCry.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteInfernalCry.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -2366,7 +2366,7 @@
     "grants_skills": [
       "SupportIceBitePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IceBiteSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/IceBiteSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2399,7 +2399,7 @@
     "grants_skills": [
       "SupportGlaciationPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/HypothermiaSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/HypothermiaSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2430,7 +2430,7 @@
     "grants_skills": [
       "SupportChanceToShockPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ConductionSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ConductionSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -2459,7 +2459,7 @@
     "grants_skills": [
       "RollingMagmaPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressRollingMagma.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressRollingMagma.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2493,7 +2493,7 @@
     "grants_skills": [
       "FrostBombPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressFrostBomb.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressFrostBomb.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2528,7 +2528,7 @@
     "grants_skills": [
       "OrbOfStormsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressOrbOfStorms.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressOrbOfStorms.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2565,7 +2565,7 @@
     "grants_skills": [
       "EarthquakePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteEarthquake.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteEarthquake.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -2600,7 +2600,7 @@
     "grants_skills": [
       "ContagionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchContagion.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchContagion.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2632,7 +2632,7 @@
     "grants_skills": [
       "WitherPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Wither.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/Wither.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2667,7 +2667,7 @@
     "grants_skills": [
       "EssenceDrainPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchEssenceDrain.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchEssenceDrain.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2701,7 +2701,7 @@
     "grants_skills": [
       "SupportControlledDestructionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ControlledDestructionSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ControlledDestructionSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2733,7 +2733,7 @@
     "grants_skills": [
       "SunderPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteSunder.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteSunder.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -2768,7 +2768,7 @@
     "grants_skills": [
       "FrostboltPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressFrostbolt.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressFrostbolt.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2803,7 +2803,7 @@
     "grants_skills": [
       "SupportElementalFocusPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ElementalFocusSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ElementalFocusSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2831,7 +2831,7 @@
     "grants_skills": [
       "DarkPactPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SkeletalChains.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SkeletalChains.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2866,7 +2866,7 @@
     "grants_skills": [
       "SummonSkeletalWarriorsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchWarriorSkeleton.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchWarriorSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2900,7 +2900,7 @@
       "SummonSkeletalReaversPlayer",
       "CommandSkeletalReaversPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchReaverSkeleton.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchReaverSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2933,7 +2933,7 @@
     "grants_skills": [
       "SummonSkeletalBrutesPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchBruteSkeleton.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchBruteSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -2967,7 +2967,7 @@
       "SummonSkeletalSnipersPlayer",
       "CommandSkeletalSniperPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchArcherSkeleton.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchArcherSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3003,7 +3003,7 @@
       "SummonSkeletalFrostMagesPlayer",
       "CommandSkeletalFrostMagePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchFrostSkeleton.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchFrostSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3037,7 +3037,7 @@
       "SummonSkeletalStormMagesPlayer",
       "CommandSkeletalStormMagePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchStormSkeleton.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchStormSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3071,7 +3071,7 @@
       "SummonSkeletalArsonistsPlayer",
       "CommandSkeletalArsonistPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchArsonistSkeleton.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchArsonistSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3105,7 +3105,7 @@
     "grants_skills": [
       "SummonSkeletalClericsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchClericSkeleton.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchClericSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3137,7 +3137,7 @@
     "grants_skills": [
       "SupportWildfirePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IgniteProliferationSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/IgniteProliferationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3169,7 +3169,7 @@
     "grants_skills": [
       "SupportChanceToBleedPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ChanceToBleedSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ChanceToBleedSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -3200,7 +3200,7 @@
     "grants_skills": [
       "SupportChanceToPoisonPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ChanceToPoisonSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ChanceToPoisonSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -3231,7 +3231,7 @@
     "grants_skills": [
       "SupportMaimPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MaimSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/MaimSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -3262,7 +3262,7 @@
     "grants_skills": [
       "SupportImmolatePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ImmolationSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ImmolationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -3294,7 +3294,7 @@
     "grants_skills": [
       "SupportLastingShockPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LastingShockSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/LastingShockSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -3325,7 +3325,7 @@
     "grants_skills": [
       "SupportBrutalityPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BrutalitySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/BrutalitySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -3356,7 +3356,7 @@
     "grants_skills": [
       "SupportMomentumPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MomentumSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/MomentumSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -3386,7 +3386,7 @@
     "grants_skills": [
       "SupportArcaneSurgePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ArcaneSurgeSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ArcaneSurgeSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3418,7 +3418,7 @@
     "grants_skills": [
       "VulnerabilityPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/vulnerability.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/vulnerability.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3453,7 +3453,7 @@
     "grants_skills": [
       "SupportWitheringTouchPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/WitheringTouchSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/WitheringTouchSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3483,7 +3483,7 @@
     "grants_skills": [
       "SoulrendPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Soulrend.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/Soulrend.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3517,7 +3517,7 @@
     "grants_skills": [
       "SupportUnleashPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/UnleashSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/UnleashSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3548,7 +3548,7 @@
     "grants_skills": [
       "SupportCloseCombatPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CloseCombatSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/CloseCombatSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -3579,7 +3579,7 @@
     "grants_skills": [
       "SupportRagePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/RageSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/RageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -3612,7 +3612,7 @@
       "PlagueBearerPlayer",
       "PlagueBearerNovaPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerPlagueBearerSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerPlagueBearerSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -3648,7 +3648,7 @@
     "grants_skills": [
       "SupportFeedingFrenzyPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FeedingFrenzySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FeedingFrenzySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3679,7 +3679,7 @@
     "grants_skills": [
       "SupportMeatShieldPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MeatShield.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/MeatShield.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -3710,7 +3710,7 @@
     "grants_skills": [
       "SupportInfernalLegionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/InfernalLegionSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/InfernalLegionSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -3744,7 +3744,7 @@
       "ArtilleryBallistaPlayer",
       "ArtilleryBallistaProjectilePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MercArtilleryBallista.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MercArtilleryBallista.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -3780,7 +3780,7 @@
     "grants_skills": [
       "SupportSecondWindPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/SecondWindSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/SecondWindSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -3810,7 +3810,7 @@
     "grants_skills": [
       "SeismicCryPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteSeismicCry.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteSeismicCry.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -3844,7 +3844,7 @@
     "grants_skills": [
       "EarthshatterPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteEarthshatter.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteEarthshatter.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -3877,7 +3877,7 @@
     "grants_skills": [
       "SigilOfPowerPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SigilofPowerWeaponSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SigilofPowerWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3910,7 +3910,7 @@
     "grants_skills": [
       "FlameWallPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressFlameWall.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressFlameWall.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3945,7 +3945,7 @@
       "ViciousHexSupportPlayer",
       "DoomBlastPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ImpendingDoomSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ImpendingDoomSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -3980,7 +3980,7 @@
     "grants_skills": [
       "HexblastPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchHexBlast.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchHexBlast.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -4012,7 +4012,7 @@
     "grants_skills": [
       "ExsanguinatePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BloodTendrilsSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BloodTendrilsSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -4044,7 +4044,7 @@
     "grants_skills": [
       "ReapPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Bloodreap.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/Bloodreap.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -4079,7 +4079,7 @@
     "grants_skills": [
       "SupportBloodMagicPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BloodMagicSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/BloodMagicSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4109,7 +4109,7 @@
     "grants_skills": [
       "SupportBeheadPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BeheadSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/BeheadSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4142,7 +4142,7 @@
     "grants_skills": [
       "SupportExecutePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ExecuteSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ExecuteSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4172,7 +4172,7 @@
     "grants_skills": [
       "BoneshatterPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteBoneshatter.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteBoneshatter.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4206,7 +4206,7 @@
     "grants_skills": [
       "EyeOfWinterPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressEyeofWinter.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressEyeofWinter.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -4237,7 +4237,7 @@
     "grants_skills": [
       "TornadoPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DruidTornado.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DruidTornado.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -4272,7 +4272,7 @@
     "grants_skills": [
       "SupportOverchargePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/OverchargeSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/OverchargeSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4303,7 +4303,7 @@
     "grants_skills": [
       "LightningConduitPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressLightningConduit.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressLightningConduit.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -4335,7 +4335,7 @@
     "grants_skills": [
       "GalvanicFieldPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/GalvanicFieldWeaponSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/GalvanicFieldWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -4372,7 +4372,7 @@
     "grants_skills": [
       "VolcanicFissurePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteVolcanicFissure.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteVolcanicFissure.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4407,7 +4407,7 @@
     "grants_skills": [
       "RapidAssaultPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/HuntressRapidAssault.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/HuntressRapidAssault.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4439,7 +4439,7 @@
     "grants_skills": [
       "DisengagePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RetreatingThrow.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RetreatingThrow.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4473,7 +4473,7 @@
     "grants_skills": [
       "EngagePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/AdvancingStrike.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/AdvancingStrike.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4508,7 +4508,7 @@
     "grants_skills": [
       "WhirlingSlashPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/HuntressWhirlingSlash.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/HuntressWhirlingSlash.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4540,7 +4540,7 @@
     "grants_skills": [
       "SpearfieldPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/HuntressSpearField.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/HuntressSpearField.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4574,7 +4574,7 @@
       "DemonMagusPlayer",
       "SupportDemonMagusPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SpellcastingMinionSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SpellcastingMinionSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -4606,7 +4606,7 @@
     "grants_skills": [
       "StormSpearPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/HuntressStormSpear.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/HuntressStormSpear.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4638,7 +4638,7 @@
     "grants_skills": [
       "BlazingLancePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/HuntressBlazingLance.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/HuntressBlazingLance.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4669,7 +4669,7 @@
     "grants_skills": [
       "AxeChopPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/passives/axedmg.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/4k/axedmg.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4700,7 +4700,7 @@
     "grants_skills": [
       "AxeSlashPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/passives/damageaxe.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/4k/damageaxe.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4733,7 +4733,7 @@
     "grants_skills": [
       "WhirlingAssaultPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkWhirlingAssault.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkWhirlingAssault.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -4767,7 +4767,7 @@
     "grants_skills": [
       "RollingSlamPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteDoubleSlam.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteDoubleSlam.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4801,7 +4801,7 @@
     "grants_skills": [
       "EscapeShotPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerFrostEscapeShot.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerFrostEscapeShot.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4835,7 +4835,7 @@
     "grants_skills": [
       "SuperchargedSlamPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteSuperchargedSlam.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteSuperchargedSlam.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -4868,7 +4868,7 @@
     "grants_skills": [
       "EvasiveStrikePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/passives/clawsofthepride.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/4k/clawsofthepride.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4902,7 +4902,7 @@
     "grants_skills": [
       "GaleStrikePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkGaleStrikeSwing.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkGaleStrikeSwing.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -4933,7 +4933,7 @@
     "grants_skills": [
       "BladeDancePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DoubleSlash.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DoubleSlash.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -4965,7 +4965,7 @@
     "grants_skills": [
       "ClawRakePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/icondualswing.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/icondualswing.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -4997,7 +4997,7 @@
     "grants_skills": [
       "SpinningFlailPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/passives/StaffNodeDefensive.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/4k/StaffNodeDefensive.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -5029,7 +5029,7 @@
     "grants_skills": [
       "AxeExecutePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/passives/AxeNotable1.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/4k/AxeNotable1.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5060,7 +5060,7 @@
     "grants_skills": [
       "AxeLeapingChopPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/passives/AxesandAttackSpeed.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/4k/AxesandAttackSpeed.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5091,7 +5091,7 @@
     "grants_skills": [
       "AxeWhirlingSlashPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/passives/cleavage.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/4k/cleavage.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5122,7 +5122,7 @@
     "grants_skills": [
       "AxeRaisedChopPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/passives/MeleeSplashNode.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/4k/MeleeSplashNode.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5154,7 +5154,7 @@
     "grants_skills": [
       "AxeHeavyCleavePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/passives/StudiousCombatant.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/4k/StudiousCombatant.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5185,7 +5185,7 @@
     "grants_skills": [
       "KnifeFlipPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/shadowprojectiles.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/shadowprojectiles.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5219,7 +5219,7 @@
     "grants_skills": [
       "WaveOfFrostPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkFreezingBackflip.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkFreezingBackflip.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5252,7 +5252,7 @@
     "grants_skills": [
       "SwordLungePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/passives/fencing.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/4k/fencing.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -5283,7 +5283,7 @@
     "grants_skills": [
       "SwordLeapSlashPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/passives/fencing.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/4k/fencing.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -5316,7 +5316,7 @@
     "grants_skills": [
       "IceStrikePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkComboAttack.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkComboAttack.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5351,7 +5351,7 @@
     "grants_skills": [
       "SupportJaggedGroundPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/JaggedGroundSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/JaggedGroundSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5386,7 +5386,7 @@
     "grants_skills": [
       "SupportInevitableCriticalsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/InevitableCriticalsSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/InevitableCriticalsSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -5417,7 +5417,7 @@
     "grants_skills": [
       "RuthlessSupportPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/RuthlessSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/RuthlessSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5447,7 +5447,7 @@
     "grants_skills": [
       "LessDurationSupportPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LessDurationSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/LessDurationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5478,7 +5478,7 @@
     "grants_skills": [
       "FistOfWarSupportPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FistOfWarSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FistOfWarSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5511,7 +5511,7 @@
     "grants_skills": [
       "UnbreakableSupportPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/UnbreakableSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/UnbreakableSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5541,7 +5541,7 @@
     "grants_skills": [
       "MoreDurationSupportPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MoreDurationSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/MoreDurationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5572,7 +5572,7 @@
     "grants_skills": [
       "ImpactShockwaveSupportPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ImpactShockwaveSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ImpactShockwaveSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -5605,7 +5605,7 @@
     "grants_skills": [
       "SupportHexBloomPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/HexBloomSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/HexBloomSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -5637,7 +5637,7 @@
     "grants_skills": [
       "GlacialCascadePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkGlacialCascade.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkGlacialCascade.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5672,7 +5672,7 @@
     "grants_skills": [
       "CometPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressComet.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressComet.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -5703,7 +5703,7 @@
     "grants_skills": [
       "BladeNovaPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/shadowprojectiles.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/shadowprojectiles.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5735,7 +5735,7 @@
     "grants_skills": [
       "FlameSlicePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/passives/TwoHandedMeleeDamage.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/4k/TwoHandedMeleeDamage.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -5766,7 +5766,7 @@
     "grants_skills": [
       "RingOfBladesPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/ViperStrike.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/ViperStrike.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5796,7 +5796,7 @@
     "grants_skills": [
       "ComboKnifeThrowPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/shadowprojectiles.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/shadowprojectiles.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5828,7 +5828,7 @@
     "grants_skills": [
       "TripleSlashPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/passives/fencing.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/4k/fencing.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -5859,7 +5859,7 @@
     "grants_skills": [
       "HyperSlashPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/ChargedAttack.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/ChargedAttack.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5890,7 +5890,7 @@
     "grants_skills": [
       "ShadowDashPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/ChargedDash.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/ChargedDash.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5921,7 +5921,7 @@
     "grants_skills": [
       "ShadowAmbushPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/iconblinkstrike.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/iconblinkstrike.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -5952,7 +5952,7 @@
     "grants_skills": [
       "StaffConsecratePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/BuffIcons/consecrated.dds",
+    "icon_dds_file": "Art/2DArt/BuffIcons/4k/consecrated.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -5987,7 +5987,7 @@
       "RipwireBallistaPlayer",
       "RipwireBallistaProjectilePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MercRipwireBallista.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MercRipwireBallista.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -6021,7 +6021,7 @@
     "grants_skills": [
       "ManaTempestPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressManaTempest.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressManaTempest.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6054,7 +6054,7 @@
     "grants_skills": [
       "KillingPalmPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkKillingPalm.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkKillingPalm.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -6090,7 +6090,7 @@
       "ShatteringPalmPlayer",
       "ShatteringPalmExplosionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkShatteringPalm.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkShatteringPalm.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -6124,7 +6124,7 @@
     "grants_skills": [
       "VolcanoPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DruidVolcano.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DruidVolcano.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -6158,7 +6158,7 @@
     "grants_skills": [
       "SummonWolfCompanionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DruidSummonWolf.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DruidSummonWolf.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -6190,7 +6190,7 @@
     "grants_skills": [
       "SupportChillingIcePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FrozenNexusSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FrozenNexusSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6220,7 +6220,7 @@
     "grants_skills": [
       "SupportFrozenVortexPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FrozenVortexSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FrozenVortexSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6251,7 +6251,7 @@
     "grants_skills": [
       "SpinningThrowPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/ghostlythrow.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/ghostlythrow.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -6283,7 +6283,7 @@
     "grants_skills": [
       "SpiralVolleyPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerSpiralVolleySkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerSpiralVolleySkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -6314,7 +6314,7 @@
     "grants_skills": [
       "BearMaulPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DruidBearMaul.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DruidBearMaul.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -6345,7 +6345,7 @@
     "grants_skills": [
       "DodgeRollPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Rolldodge.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/Rolldodge.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -6373,7 +6373,7 @@
     "grants_skills": [
       "ShadowThiefSlashPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/passives/AreaofEffectofMinionsNotable.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/passives/4k/AreaofEffectofMinionsNotable.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -6403,7 +6403,7 @@
     "grants_skills": [
       "LeapingAxeCatchPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/iconleapslam.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/iconleapslam.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -6434,7 +6434,7 @@
     "grants_skills": [
       "StormBladePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Upheaval.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/Upheaval.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -6466,7 +6466,7 @@
     "grants_skills": [
       "PlungingBladePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/TectonicSlam.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/TectonicSlam.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -6496,7 +6496,7 @@
     "grants_skills": [
       "WolfHowlPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DruidWolfHowl.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DruidWolfHowl.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -6525,7 +6525,7 @@
     "grants_skills": [
       "SpiralThrowPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/ghostlythrow.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/ghostlythrow.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -6555,7 +6555,7 @@
     "grants_skills": [
       "WolfLeapAttackPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DruidWolfLeapAttack.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DruidWolfLeapAttack.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -6586,7 +6586,7 @@
     "grants_skills": [
       "LightningBoltPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/LightningBoltSkillStaff.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/LightningBoltSkillStaff.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6617,7 +6617,7 @@
     "grants_skills": [
       "BearRampagePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DruidBearRampage.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DruidBearRampage.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -6682,7 +6682,7 @@
     "grants_skills": [
       "SupportEnergyShieldOnShockKillPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ShockSiphonSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ShockSiphonSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6711,7 +6711,7 @@
     "grants_skills": [
       "StaffUnleashNextSpellPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/UnleashSkillStaff.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/UnleashSkillStaff.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6744,7 +6744,7 @@
     "grants_skills": [
       "SupportCoursingCurrentPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ShockingProliferationSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ShockingProliferationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6776,7 +6776,7 @@
     "grants_skills": [
       "SupportLastingFrostPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DeepFreezeSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/DeepFreezeSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6805,7 +6805,7 @@
     "grants_skills": [
       "LightningStormPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/LightningStormSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/LightningStormSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -6867,7 +6867,7 @@
     "grants_skills": [
       "SupportChanceToIgnitePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IgnitionSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/IgnitionSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -6898,7 +6898,7 @@
     "grants_skills": [
       "SupportDeadlyIgnitesPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/SearingFlameSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/SearingFlameSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -6929,7 +6929,7 @@
     "grants_skills": [
       "SupportIgniteDurationPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/EternalFlameSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/EternalFlameSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -6987,7 +6987,7 @@
     "grants_skills": [
       "BearSlamPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DruidBearSlam.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DruidBearSlam.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -7020,7 +7020,7 @@
       "BearWarcryMetaPlayer",
       "SupportBearWarcryPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DruidBearWarcry.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DruidBearWarcry.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -7055,7 +7055,7 @@
       "SupportMetaCastOnShockPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnShockSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/CastOnShockSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7122,7 +7122,7 @@
       "SupportMetaCastOnFreezePlayer",
       "SupportInvisibleMetaGemSupport"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnFreezeSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/CastOnFreezeSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7159,7 +7159,7 @@
       "SupportMetaCastOnIgnitePlayer",
       "SupportInvisibleMetaGemSupport"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnIgniteSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/CastOnIgniteSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7194,7 +7194,7 @@
       "SupportMetaCastOnMeleeKillPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnMeleeKillSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/CastOnMeleeKillSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -7228,7 +7228,7 @@
       "SupportMetaCastOnDeathPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DeathWalk.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DeathWalk.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -7264,7 +7264,7 @@
       "SupportMetaCastOnCritPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnCritSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/CastOnCritSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7298,7 +7298,7 @@
       "SupportMetaCastWhenStunnedPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/TectonicSlam.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/TectonicSlam.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7332,7 +7332,7 @@
       "SupportMetaCastWhenDamageTakenPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/icononfire.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/icononfire.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -7366,7 +7366,7 @@
     "grants_skills": [
       "SupportExploitWeaknessPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ExploitWeaknessSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ExploitWeaknessSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -7397,7 +7397,7 @@
     "grants_skills": [
       "SupportDevastatePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DevastateSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/DevastateSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -7432,7 +7432,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7467,7 +7467,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7502,7 +7502,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7537,7 +7537,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 33,
       "intelligence": 34,
@@ -7572,7 +7572,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7607,7 +7607,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7643,7 +7643,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7678,7 +7678,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7713,7 +7713,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7750,7 +7750,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7785,7 +7785,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7822,7 +7822,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7857,7 +7857,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7894,7 +7894,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7929,7 +7929,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -7968,7 +7968,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -8003,7 +8003,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -8031,7 +8031,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -8059,7 +8059,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -8087,7 +8087,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -8115,7 +8115,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -8143,7 +8143,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -8171,7 +8171,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -8199,7 +8199,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -8227,7 +8227,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -8255,7 +8255,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -8283,7 +8283,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -8318,7 +8318,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8355,7 +8355,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8392,7 +8392,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8429,7 +8429,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8466,7 +8466,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8505,7 +8505,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8542,7 +8542,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8579,7 +8579,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8619,7 +8619,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8651,7 +8651,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8681,7 +8681,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8711,7 +8711,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8741,7 +8741,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8771,7 +8771,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8801,7 +8801,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8831,7 +8831,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8861,7 +8861,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8891,7 +8891,7 @@
     "grants_skills": [
       "DoLiterallyNothingPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -8924,7 +8924,7 @@
       "SupportBarrierInvocationPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressBarrierInvocation.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressBarrierInvocation.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -8960,7 +8960,7 @@
       "SupportMetaCastOnDodgePlayer",
       "SupportInvisibleMetaGemSupport"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnDodgeRollSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/CastOnDodgeRollSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -8994,7 +8994,7 @@
       "SupportMetaCastWhileChannellingPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/CastWhileChannellingSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/CastWhileChannellingSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -9028,7 +9028,7 @@
       "SupportMetaCastOnMeleeStunPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnMeleeStunSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/CastOnMeleeStunSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -9062,7 +9062,7 @@
     "grants_skills": [
       "SupportEnragedWarcryPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/EnragedWarcrySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/EnragedWarcrySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -9094,7 +9094,7 @@
       "LingeringIllusionPlayer",
       "LingeringIllusionSpawnPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkLingeringIllusion.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkLingeringIllusion.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -9127,7 +9127,7 @@
     "grants_skills": [
       "GhostDancePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkGhostDance.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkGhostDance.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -9158,7 +9158,7 @@
     "grants_skills": [
       "BindSpectrePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchBindSpectre.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchBindSpectre.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -9187,7 +9187,7 @@
     "grants_skills": [
       "DominatingAuraPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SpellDamageAura.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SpellDamageAura.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -9221,7 +9221,7 @@
     "grants_skills": [
       "ShroudPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/AmbushIcon.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/AmbushIcon.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -9254,7 +9254,7 @@
       "SummonMercenaryCompanionSupportPlayer",
       "CommandUnloadAmmoPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SummonMercCompanion.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SummonMercCompanion.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -9289,7 +9289,7 @@
       "AncestralWarriorTotemPlayer",
       "SupportAncestralWarriorTotemPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteAncestralWarriorTotem.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteAncestralWarriorTotem.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -9325,7 +9325,7 @@
       "SummonMetaTotemSpellTotemPlayer",
       "SupportMetaTotemSpellTotemPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SpellMetaTotem.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SpellMetaTotem.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -9357,7 +9357,7 @@
       "SummonMetaTotemBallistaPlayer",
       "SupportMetaTotemBallistaPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangedMetaTotem.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangedMetaTotem.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -9390,7 +9390,7 @@
     "grants_skills": [
       "ExplosiveGrenadePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/ExplosiveGrenade.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/ExplosiveGrenade.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -9427,7 +9427,7 @@
     "grants_skills": [
       "FlashGrenadePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/FlashbangGrenade.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/FlashbangGrenade.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -9462,7 +9462,7 @@
     "grants_skills": [
       "OilGrenadePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/OilGrenade.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/OilGrenade.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -9498,7 +9498,7 @@
     "grants_skills": [
       "ToxicGrenadePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/ToxicGrenade.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/ToxicGrenade.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -9535,7 +9535,7 @@
     "grants_skills": [
       "ShockGrenadePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/ShockGrenade.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/ShockGrenade.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -9571,7 +9571,7 @@
     "grants_skills": [
       "PainOfferingPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchPainOffering.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchPainOffering.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -9605,7 +9605,7 @@
     "grants_skills": [
       "TempestFlurryPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkTempestFlurry.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkTempestFlurry.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -9642,7 +9642,7 @@
       "StaggeringPalmProjectilePlayer",
       "StaggeringPalmUnarmedProjectilePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkWindPalm.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkWindPalm.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -9680,7 +9680,7 @@
       "ChargedStaffPlayer",
       "ChargedStaffShockwavePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkChargedStaff.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkChargedStaff.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -9715,7 +9715,7 @@
     "grants_skills": [
       "SiphoningStrikePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkSiphoningStrike.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkSiphoningStrike.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -9751,7 +9751,7 @@
     "grants_skills": [
       "TempestBellPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkTempestBell.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkTempestBell.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -9785,7 +9785,7 @@
     "grants_skills": [
       "WeaponGrantedChaosboltPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/ChaosBoltWeaponSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/ChaosBoltWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -9819,7 +9819,7 @@
       "FrozenLocusPlayer",
       "FrozenLocusExplodePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkIceAmbush.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkIceAmbush.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -9855,7 +9855,7 @@
     "grants_skills": [
       "BonestormPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchBoneStorm.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchBoneStorm.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -9892,7 +9892,7 @@
     "grants_skills": [
       "BoneCagePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchBoneCage.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchBoneCage.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -9956,7 +9956,7 @@
     "grants_skills": [
       "SupportNeuralOverloadPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/NeuralOverloadSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/NeuralOverloadSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10016,7 +10016,7 @@
     "grants_skills": [
       "SupportPerpetualChargePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PerpetualChargeSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/PerpetualChargeSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10046,7 +10046,7 @@
     "grants_skills": [
       "SupportCorrosionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CorrosionSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/CorrosionSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10078,7 +10078,7 @@
     "grants_skills": [
       "UnearthPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchUnearth.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchUnearth.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10113,7 +10113,7 @@
     "grants_skills": [
       "DetonatingArrowPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerDetonatingArrowSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerDetonatingArrowSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10149,7 +10149,7 @@
     "grants_skills": [
       "PoisonBurstArrowPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerPoisonBurstArrow.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerPoisonBurstArrow.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10182,7 +10182,7 @@
     "grants_skills": [
       "FireboltPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/FireballSkillStaff.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/FireballSkillStaff.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10216,7 +10216,7 @@
     "grants_skills": [
       "ToxicGrowthPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerPoisonBloomSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerPoisonBloomSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10251,7 +10251,7 @@
     "grants_skills": [
       "StormcallerArrowPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerShockingArrow.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerShockingArrow.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10286,7 +10286,7 @@
     "grants_skills": [
       "LightningRodPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerLightningRodRainSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerLightningRodRainSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10322,7 +10322,7 @@
     "grants_skills": [
       "SnipePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerSnipeShotArrow.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerSnipeShotArrow.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10356,7 +10356,7 @@
     "grants_skills": [
       "GasArrowPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerGasCloudSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerGasCloudSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10392,7 +10392,7 @@
     "grants_skills": [
       "SolarOrbPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressSolarOrb.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressSolarOrb.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10428,7 +10428,7 @@
     "grants_skills": [
       "FireballPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressGreaterFireball.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressGreaterFireball.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10462,7 +10462,7 @@
     "grants_skills": [
       "ElectrocutingArrowPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerElectrocutingRodSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerElectrocutingRodSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10496,7 +10496,7 @@
     "grants_skills": [
       "ColdSnapPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressColdSnap.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressColdSnap.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10530,7 +10530,7 @@
     "grants_skills": [
       "PerfectStrikePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BrutePerfectStrike.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BrutePerfectStrike.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -10565,7 +10565,7 @@
     "grants_skills": [
       "ShieldBlockPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteShieldBlock.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteShieldBlock.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -10596,7 +10596,7 @@
     "grants_skills": [
       "ResonatingShieldPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteResonatingShield.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteResonatingShield.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -10632,7 +10632,7 @@
     "grants_skills": [
       "ManaRemnantsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressEnergyRemnants.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressEnergyRemnants.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10666,7 +10666,7 @@
       "MagmaBarrierPlayer",
       "MagmaSprayPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteMagmaBarrier.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteMagmaBarrier.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -10702,7 +10702,7 @@
     "grants_skills": [
       "FreezingShardsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/FreezingShardsStaff.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/FreezingShardsStaff.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10735,7 +10735,7 @@
     "grants_skills": [
       "VineArrowPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerPoisonVineArrowSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerPoisonVineArrowSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10768,7 +10768,7 @@
     "grants_skills": [
       "SummonRhoaMountPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SummonBeastRhoa.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SummonBeastRhoa.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10803,7 +10803,7 @@
       "SupportBurstingPlaguePlayer",
       "PlagueBurstPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BurstingPlagueSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/BurstingPlagueSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10836,7 +10836,7 @@
     "grants_skills": [
       "CorpseCloudPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DecomposeSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DecomposeSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10871,7 +10871,7 @@
     "grants_skills": [
       "SupportWallFortressPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/WallFortressSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/WallFortressSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10901,7 +10901,7 @@
     "grants_skills": [
       "SupportFrostfirePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FrostfireSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FrostfireSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10934,7 +10934,7 @@
     "grants_skills": [
       "SupportStormfirePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/StormfireSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/StormfireSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -10966,7 +10966,7 @@
     "grants_skills": [
       "SupportIncreaseLimitPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IncreaseLimitSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/IncreaseLimitSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -10996,7 +10996,7 @@
     "grants_skills": [
       "SupportElectrocutePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ElectrocuteSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ElectrocuteSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11027,7 +11027,7 @@
     "grants_skills": [
       "RagingSpiritsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchReservationRaginSpirits.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchReservationRaginSpirits.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11062,7 +11062,7 @@
     "grants_skills": [
       "SupportEnergyBarrierPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/EnergyBarrierSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/EnergyBarrierSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11093,7 +11093,7 @@
       "SupportKnockbackWavePlayer",
       "KnockbackWavePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/KnockbackWaveSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/KnockbackWaveSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11126,7 +11126,7 @@
     "grants_skills": [
       "SupportBitingFrostPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BitingFrostSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/BitingFrostSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11159,7 +11159,7 @@
       "SupportElementalDischargePlayer",
       "TriggeredElementalDischargePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ElementalDischargeSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ElementalDischargeSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11195,7 +11195,7 @@
     "grants_skills": [
       "SupportHourglassPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/HourglassSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/HourglassSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11226,7 +11226,7 @@
       "SupportFieryDeathPlayer",
       "TriggeredFieryDeathPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FieryDeathSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FieryDeathSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11257,7 +11257,7 @@
     "grants_skills": [
       "SandstormSwipePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SandBladeStorm.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SandBladeStorm.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11288,7 +11288,7 @@
     "grants_skills": [
       "DestructiveLinkSkeletonBombadierMinion"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchArsonistSkeleton.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchArsonistSkeleton.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11319,7 +11319,7 @@
     "grants_skills": [
       "RemoteSpearMinePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BlastRain.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BlastRain.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11349,7 +11349,7 @@
     "grants_skills": [
       "SpearWindVortexPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Tornado.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/Tornado.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11381,7 +11381,7 @@
       "SpearInfusingStrikePlayer",
       "InfusedSpearMinePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/ElementalStrike.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/ElementalStrike.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11416,7 +11416,7 @@
     "grants_skills": [
       "SpearLightningWarpPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressLightningWarp.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressLightningWarp.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11450,7 +11450,7 @@
       "WindDancerPlayer",
       "TriggeredWindDancerPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerWindDancerSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerWindDancerSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11544,7 +11544,7 @@
       "SupportManaFlarePlayer",
       "TriggeredManaFlarePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ManaFlareSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ManaFlareSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11578,7 +11578,7 @@
     "grants_skills": [
       "SupportLockdownPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LockdownSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/LockdownSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11609,7 +11609,7 @@
     "grants_skills": [
       "SupportOverpowerPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/OverpowerSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/OverpowerSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -11639,7 +11639,7 @@
     "grants_skills": [
       "SupportMobilityPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MobilitySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/MobilitySupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11669,7 +11669,7 @@
     "grants_skills": [
       "SupportPinPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PinSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/PinSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11700,7 +11700,7 @@
     "grants_skills": [
       "SupportAmbushPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AmbushSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/AmbushSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11731,7 +11731,7 @@
     "grants_skills": [
       "ProfaneRitualPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchProfaneRitual.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchProfaneRitual.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11765,7 +11765,7 @@
     "grants_skills": [
       "SoulOfferingPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchPowerOffering.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchPowerOffering.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11799,7 +11799,7 @@
       "DarkEffigyPlayer",
       "DarkEffigyProjectilePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchDarkEffigy.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchDarkEffigy.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11835,7 +11835,7 @@
     "grants_skills": [
       "SupportManaFlaskPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ManaFlaskSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ManaFlaskSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11865,7 +11865,7 @@
     "grants_skills": [
       "SupportLifeFlaskPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LifeFlaskSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/LifeFlaskSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -11893,7 +11893,7 @@
     "grants_skills": [
       "WeaponGrantedSummonSkeletalWarriorsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchWarriorSkeleton.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchWarriorSkeleton.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 75,
@@ -11926,7 +11926,7 @@
     "grants_skills": [
       "SupportMinionInstabilityPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MinionInstabilitySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/MinionInstabilitySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -11958,7 +11958,7 @@
     "grants_skills": [
       "SupportEnduranceChargeOnArmourBreak"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BreakEndurance.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/BreakEndurance.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -11988,7 +11988,7 @@
     "grants_skills": [
       "SupportCurseEffectPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CurseEffectSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/CurseEffectSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12019,7 +12019,7 @@
     "grants_skills": [
       "SupportCorpseConservationPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CorpseConservationSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/CorpseConservationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12049,7 +12049,7 @@
     "grants_skills": [
       "SupportDecayingHexPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DecayingHexSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/DecayingHexSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12081,7 +12081,7 @@
     "grants_skills": [
       "SupportFocusedCursePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FocusedHexSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FocusedHexSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12112,7 +12112,7 @@
     "grants_skills": [
       "SupportRitualisticCursePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/RitualisticCurseSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/RitualisticCurseSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12143,7 +12143,7 @@
     "grants_skills": [
       "SupportMinionPactPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MinionPactSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/MinionPactSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12174,7 +12174,7 @@
     "grants_skills": [
       "SupportLastGaspPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LastGaspSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/LastGaspSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12207,7 +12207,7 @@
     "grants_skills": [
       "SupportLifeOnCullPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LifeOnCull.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/LifeOnCull.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -12237,7 +12237,7 @@
     "grants_skills": [
       "SupportManaOnCullPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ManaOnCull.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ManaOnCull.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -12267,7 +12267,7 @@
     "grants_skills": [
       "GrimFeastPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchGrimFeast.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchGrimFeast.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12300,7 +12300,7 @@
     "grants_skills": [
       "SupportInnervatePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/Innervate.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/Innervate.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -12335,7 +12335,7 @@
       "SupportMetaCastOnMinionDeathPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnMinionDeath.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/CastOnMinionDeath.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12370,7 +12370,7 @@
     "grants_skills": [
       "SupportMultiplePoisonPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MultiplePoisonSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/MultiplePoisonSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -12401,7 +12401,7 @@
     "grants_skills": [
       "SupportMultipleChargesPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/MultipleChargesSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/MultipleChargesSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -12431,7 +12431,7 @@
     "grants_skills": [
       "SupportEmpoweredDamagePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/EmpoweredDamageSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/EmpoweredDamageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -12461,7 +12461,7 @@
     "grants_skills": [
       "SupportEmpoweredCullPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/EmpoweredCullSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/EmpoweredCullSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -12491,7 +12491,7 @@
     "grants_skills": [
       "ScavengedPlatingPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteScavengedPlating.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteScavengedPlating.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -12523,7 +12523,7 @@
     "grants_skills": [
       "SpinningInfernoPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/FlamesOfJudgement.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/FlamesOfJudgement.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -12556,7 +12556,7 @@
     "grants_skills": [
       "ManaDrainPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/ManaDrainWeaponSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/ManaDrainWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12585,7 +12585,7 @@
     "grants_skills": [
       "BoneBlastPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BoneBlastWeaponSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BoneBlastWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12620,7 +12620,7 @@
       "BlinkReservationPlayer",
       "BlinkPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressBlinkReservation.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressBlinkReservation.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12653,7 +12653,7 @@
     "grants_skills": [
       "MoltenBlastPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteMoltenBlast.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteMoltenBlast.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -12685,7 +12685,7 @@
     "grants_skills": [
       "MalicePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MaliceWeaponSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MaliceWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 75,
@@ -12719,7 +12719,7 @@
       "HydraPlayer",
       "SupportHydraPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/AncestorTotemSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/AncestorTotemSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12754,7 +12754,7 @@
     "grants_skills": [
       "HammerOfTheGodsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteHammerOfTheGods.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteHammerOfTheGods.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -12787,7 +12787,7 @@
     "grants_skills": [
       "LivingBombPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/LivingBombWeaponSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/LivingBombWeaponSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12821,7 +12821,7 @@
     "grants_skills": [
       "StampedePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteStampede.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteStampede.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -12857,7 +12857,7 @@
     "grants_skills": [
       "ShieldWallPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteShieldWall.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteShieldWall.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -12890,7 +12890,7 @@
       "ShieldingCryPlayer",
       "ShieldingCryShockwavePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WarCryIntimidating.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WarCryIntimidating.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -12927,7 +12927,7 @@
     "grants_skills": [
       "BlazingClusterPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressBlazingCluster.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressBlazingCluster.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -12963,7 +12963,7 @@
       "HighVelocityRoundsAmmoPlayer",
       "HighVelocityRoundsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/PowerShotPhysical.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/PowerShotPhysical.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -12999,7 +12999,7 @@
       "FragmentationRoundsAmmoPlayer",
       "FragmentationRoundsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BurstShotPhysical.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BurstShotPhysical.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -13034,7 +13034,7 @@
       "SiegeCascadeAmmoPlayer",
       "SiegeCascadePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SiegeCascadeIncendiary.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SiegeCascadeIncendiary.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -13072,7 +13072,7 @@
       "ArmourPiercingBoltsAmmoPlayer",
       "ArmourPiercingBoltsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RapidShotPhysical.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RapidShotPhysical.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -13107,7 +13107,7 @@
       "ExplosiveShotAmmoPlayer",
       "ExplosiveShotPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/PowerShotIncendiary.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/PowerShotIncendiary.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -13144,7 +13144,7 @@
       "IncendiaryShotAmmoPlayer",
       "IncendiaryShotPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BurstShotIncendiary.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BurstShotIncendiary.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -13180,7 +13180,7 @@
       "RapidShotAmmoPlayer",
       "RapidShotPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RapidShotIncendiary.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RapidShotIncendiary.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -13215,7 +13215,7 @@
       "GlacialBoltAmmoPlayer",
       "GlacialBoltPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/PowerShotPermafrost.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/PowerShotPermafrost.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -13252,7 +13252,7 @@
       "PermafrostBoltsAmmoPlayer",
       "PermafrostBoltsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BurstShotPermafrost.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BurstShotPermafrost.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -13288,7 +13288,7 @@
       "HailstormRoundsAmmoPlayer",
       "HailstormRoundsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SiegeCascadePermafrost.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SiegeCascadePermafrost.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -13325,7 +13325,7 @@
       "IceShardsAmmoPlayer",
       "IceShardsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RapidShotPermafrost.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RapidShotPermafrost.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -13362,7 +13362,7 @@
       "PlasmaBlastAmmoPlayer",
       "PlasmaBlastPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/PowerShotStormblast.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/PowerShotStormblast.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -13399,7 +13399,7 @@
       "GalvanicShardsAmmoPlayer",
       "GalvanicShardsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BurstShotStormblast.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BurstShotStormblast.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -13435,7 +13435,7 @@
       "StormblastBoltsAmmoPlayer",
       "StormblastBoltsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SiegeCascadeStormblast.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SiegeCascadeStormblast.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -13472,7 +13472,7 @@
       "ShockburstRoundsAmmoPlayer",
       "ShockburstRoundsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RapidShotStormblast.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RapidShotStormblast.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -13508,7 +13508,7 @@
     "grants_skills": [
       "SupportRagingCryPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/RagingCrySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/RagingCrySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13539,7 +13539,7 @@
     "grants_skills": [
       "SupportIncreasedArmourBreakPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IncreasedArmourBreakSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/IncreasedArmourBreakSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13570,7 +13570,7 @@
     "grants_skills": [
       "SupportRageforgedPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/RageforgedSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/RageforgedSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13598,7 +13598,7 @@
     "grants_skills": [
       "MeleeUnarmedPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/UnarmedDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/UnarmedDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13630,7 +13630,7 @@
     "grants_skills": [
       "MeleeQuarterstaffPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/QuarterstaffDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/QuarterstaffDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13662,7 +13662,7 @@
     "grants_skills": [
       "MeleeFlailPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/FlailDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/FlailDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13694,7 +13694,7 @@
     "grants_skills": [
       "Melee1HSwordPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/OneHandSwordDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/OneHandSwordDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13726,7 +13726,7 @@
     "grants_skills": [
       "MeleeSwordSwordPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DualWieldSwordDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DualWieldSwordDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13758,7 +13758,7 @@
     "grants_skills": [
       "Melee2HSwordPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/TwoHandSwordDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/TwoHandSwordDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13790,7 +13790,7 @@
     "grants_skills": [
       "Melee1HAxePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/OneHandAxeDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/OneHandAxeDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13822,7 +13822,7 @@
     "grants_skills": [
       "MeleeAxeAxePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DualWieldAxeDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DualWieldAxeDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13854,7 +13854,7 @@
     "grants_skills": [
       "Melee2HAxePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/TwoHandAxeDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/TwoHandAxeDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13886,7 +13886,7 @@
     "grants_skills": [
       "Melee1HMacePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/OneHandMaceDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/OneHandMaceDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13918,7 +13918,7 @@
     "grants_skills": [
       "MeleeMaceMacePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DualWieldMaceDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DualWieldMaceDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13950,7 +13950,7 @@
     "grants_skills": [
       "Melee2HMacePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/TwoHandMaceDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/TwoHandMaceDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -13982,7 +13982,7 @@
     "grants_skills": [
       "MeleeClawPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/OneHandClawDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/OneHandClawDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14014,7 +14014,7 @@
     "grants_skills": [
       "MeleeClawClawPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DualWieldClawDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DualWieldClawDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14046,7 +14046,7 @@
     "grants_skills": [
       "MeleeDaggerPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/OneHandDaggerDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/OneHandDaggerDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14078,7 +14078,7 @@
     "grants_skills": [
       "MeleeDaggerDaggerPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/TwoHandDaggerDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/TwoHandDaggerDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14110,7 +14110,7 @@
     "grants_skills": [
       "MeleeSpearPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SpearDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SpearDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14142,7 +14142,7 @@
     "grants_skills": [
       "MeleeBowPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BowDefaultSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BowDefaultSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14172,7 +14172,7 @@
     "grants_skills": [
       "MeleeCrossbowPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/PowerShot.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/PowerShot.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14203,7 +14203,7 @@
     "grants_skills": [
       "PlaytestAttack"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/iconbasicattack.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/iconbasicattack.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14235,7 +14235,7 @@
     "grants_skills": [
       "PlaytestSlam"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteLeapSlam.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteLeapSlam.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14268,7 +14268,7 @@
     "grants_skills": [
       "PlaytestSpell"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/FireballSkillStaff.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/FireballSkillStaff.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14300,7 +14300,7 @@
     "grants_skills": [
       "LifeRemnantsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BloodChannel.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BloodChannel.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14330,7 +14330,7 @@
     "grants_skills": [
       "ExplosiveConcoctionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerBrewConcoctionFireSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerBrewConcoctionFireSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14363,7 +14363,7 @@
     "grants_skills": [
       "FulminatingConcoctionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerBrewConcoctionLightningSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerBrewConcoctionLightningSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14396,7 +14396,7 @@
     "grants_skills": [
       "ShatteringConcoctionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerBrewConcoctionColdSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerBrewConcoctionColdSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14429,7 +14429,7 @@
     "grants_skills": [
       "PoisonousConcoctionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerBrewConcoctionPoisonSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerBrewConcoctionPoisonSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14461,7 +14461,7 @@
     "grants_skills": [
       "BleedingConcoctionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerBrewConcoctionBleedSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerBrewConcoctionBleedSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14493,7 +14493,7 @@
     "grants_skills": [
       "MeditatePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkInvokerMeditate.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkInvokerMeditate.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14523,7 +14523,7 @@
     "grants_skills": [
       "ElementalStormPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressElementalStorm.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressElementalStorm.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14559,7 +14559,7 @@
     "grants_skills": [
       "UnboundAvatarPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkInvokerUnboundAvatar.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkInvokerUnboundAvatar.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14592,7 +14592,7 @@
     "grants_skills": [
       "SummonInfernalHoundPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchSummonInfernalFamiliar.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchSummonInfernalFamiliar.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14623,7 +14623,7 @@
     "grants_skills": [
       "TemporalRiftPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressTemporalistTemporalRift.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressTemporalistTemporalRift.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14654,7 +14654,7 @@
     "grants_skills": [
       "TimeFreezePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressTemporalistTimeStop.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressTemporalistTimeStop.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14685,7 +14685,7 @@
     "grants_skills": [
       "TimeSnapPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressTemporalistReloadCooldown.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressTemporalistReloadCooldown.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14714,7 +14714,7 @@
     "grants_skills": [
       "EncaseInJadePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteWarbringerEncasedJade.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteWarbringerEncasedJade.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14747,7 +14747,7 @@
     "grants_skills": [
       "DemonFormPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchTransformDemon.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchTransformDemon.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14778,7 +14778,7 @@
     "grants_skills": [
       "SorceryWardPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchunterSpellAegis.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchunterSpellAegis.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14812,7 +14812,7 @@
     "grants_skills": [
       "IntoTheBreachPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkBreachWalk.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkBreachWalk.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14842,7 +14842,7 @@
     "grants_skills": [
       "AncestralSpiritsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BruteWarbringerDefenders.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BruteWarbringerDefenders.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14876,7 +14876,7 @@
       "SupportArmourExplosionPlayer",
       "ArmourExplosionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ArmourExplosionSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ArmourExplosionSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14913,7 +14913,7 @@
       "SupportStompingGroundPlayer",
       "StompingGroundShockwavePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/StompingGroundSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/StompingGroundSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -14947,7 +14947,7 @@
     "grants_skills": [
       "SupportCrescendoPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ExtendedCombo.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ExtendedCombo.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -14980,7 +14980,7 @@
     "grants_skills": [
       "SupportFireExposurePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FireExposureSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FireExposureSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -15012,7 +15012,7 @@
     "grants_skills": [
       "SupportLightningExposurePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LightningExposureSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/LightningExposureSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15044,7 +15044,7 @@
     "grants_skills": [
       "SupportColdExposurePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ColdExposureSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ColdExposureSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15077,7 +15077,7 @@
     "grants_skills": [
       "SupportDeadlyPoisonPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DeadlyPoisonSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/DeadlyPoisonSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15108,7 +15108,7 @@
     "grants_skills": [
       "SupportDeepCutsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DeepCutsSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/DeepCutsSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -15139,7 +15139,7 @@
     "grants_skills": [
       "SupportCorruptingCryPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CorruptingCrySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/CorruptingCrySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -15172,7 +15172,7 @@
     "grants_skills": [
       "SupportWindowOfOpportunityPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/WindowOfOpportunitySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/WindowOfOpportunitySupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15203,7 +15203,7 @@
     "grants_skills": [
       "SupportFireMasteryPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FireMasterySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FireMasterySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15234,7 +15234,7 @@
     "grants_skills": [
       "SupportColdMasteryPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ColdMasterySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ColdMasterySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15265,7 +15265,7 @@
     "grants_skills": [
       "SupportLightningMasteryPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LightningMasterySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/LightningMasterySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15296,7 +15296,7 @@
     "grants_skills": [
       "SupportChaosMasteryPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ChaosMasterySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ChaosMasterySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15327,7 +15327,7 @@
     "grants_skills": [
       "SupportPhysicalMasteryPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PhysicalMasterySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/PhysicalMasterySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15358,7 +15358,7 @@
     "grants_skills": [
       "SupportMinionMasteryPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PhysicalMasterySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/PhysicalMasterySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15389,7 +15389,7 @@
     "grants_skills": [
       "ShockchainArrowPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerShockchainSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerShockchainSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15425,7 +15425,7 @@
     "grants_skills": [
       "VaultingImpactPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkVaultingImpact.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkVaultingImpact.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -15460,7 +15460,7 @@
     "grants_skills": [
       "StormWavePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkStormWave.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkStormWave.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -15494,7 +15494,7 @@
     "grants_skills": [
       "MantraOfDestructionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkMantraofDestruction.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkMantraofDestruction.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -15527,7 +15527,7 @@
     "grants_skills": [
       "SupportSwiftAfflictionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/SwiftAfflictionSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/SwiftAfflictionSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15558,7 +15558,7 @@
     "grants_skills": [
       "SupportChaoticAssassinationPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IntenseAgonySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/IntenseAgonySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15590,7 +15590,7 @@
     "grants_skills": [
       "SupportDrainedAilmentPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DrainedAilmentSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/DrainedAilmentSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15621,7 +15621,7 @@
     "grants_skills": [
       "SupportChaoticFreezePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ChaoticFreezeSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ChaoticFreezeSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15653,7 +15653,7 @@
     "grants_skills": [
       "SupportHinderPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/HinderSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/HinderSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15683,7 +15683,7 @@
     "grants_skills": [
       "SupportFusilladePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FusilladeSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FusilladeSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15714,7 +15714,7 @@
     "grants_skills": [
       "SupportComboFinisherPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ComboFinisherSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ComboFinisherSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15746,7 +15746,7 @@
     "grants_skills": [
       "SupportEncumberancePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/EncumberanceSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/EncumberanceSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15778,7 +15778,7 @@
     "grants_skills": [
       "SupportPrecisionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PrecisionSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/PrecisionSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -15810,7 +15810,7 @@
     "grants_skills": [
       "SupportClarityPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ClaritySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ClaritySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -15842,7 +15842,7 @@
     "grants_skills": [
       "SupportVitalityPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/VitalitySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/VitalitySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -15874,7 +15874,7 @@
     "grants_skills": [
       "SupportHerbalismPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/HerbalismSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/HerbalismSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -15906,7 +15906,7 @@
     "grants_skills": [
       "SupportCannibalismPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CannibalismSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/CannibalismSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -15936,7 +15936,7 @@
     "grants_skills": [
       "CorpsewadeCorpseCloudPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DecomposeSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DecomposeSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -15970,7 +15970,7 @@
       "SupportSoulbreakerPlayer",
       "TriggeredSoulbreakerPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/SoulbreakerSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/SoulbreakerSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -16003,7 +16003,7 @@
     "grants_skills": [
       "SupportRupturePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/RuptureSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/RuptureSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16034,7 +16034,7 @@
     "grants_skills": [
       "SupportCullingStrikePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CullingStrikeSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/CullingStrikeSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -16065,7 +16065,7 @@
     "grants_skills": [
       "SupportSpellCascadePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/SpellCascadeSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/SpellCascadeSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -16095,7 +16095,7 @@
     "grants_skills": [
       "SupportArmourBreakPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ArmourBreakSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ArmourBreakSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16125,7 +16125,7 @@
     "grants_skills": [
       "SupportFarCombatPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FarCombatSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FarCombatSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -16156,7 +16156,7 @@
     "grants_skills": [
       "SupportDazingPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DazingSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/DazingSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -16188,7 +16188,7 @@
     "grants_skills": [
       "SupportDazedBreakPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DazedBreakSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/DazedBreakSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -16219,7 +16219,7 @@
     "grants_skills": [
       "SupportDazingCryPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DazingCrySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/DazingCrySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16250,7 +16250,7 @@
     "grants_skills": [
       "SupportCursedGroundPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CursedGroundSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/CursedGroundSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -16280,7 +16280,7 @@
     "grants_skills": [
       "SupportWeaponElementalDamagePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/WeaponElementalDamageSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/WeaponElementalDamageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16311,7 +16311,7 @@
     "grants_skills": [
       "SupportCooldownReductionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CooldownReductionSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/CooldownReductionSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -16339,7 +16339,7 @@
     "grants_skills": [
       "ElementalExpressionTriggeredPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkInvokerWildStrike.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkInvokerWildStrike.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16377,7 +16377,7 @@
     "grants_skills": [
       "IceShotPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerIceShot.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerIceShot.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -16411,7 +16411,7 @@
       "WarBannerReservationPlayer",
       "WarBannerPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WarBannerSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WarBannerSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -16447,7 +16447,7 @@
       "DefianceBannerReservationPlayer",
       "DefianceBannerPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DefianceBannerSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DefianceBannerSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -16484,7 +16484,7 @@
       "DreadBannerReservationPlayer",
       "DreadBannerPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/DreadBannerSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/DreadBannerSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -16520,7 +16520,7 @@
       "FreezingMarkPlayer",
       "TriggeredFreezingMarkNovaPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/FreezingMarkSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/FreezingMarkSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -16558,7 +16558,7 @@
       "VoltaicMarkPlayer",
       "TriggeredVoltaicMarkNovaPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/ShockingMarkSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/ShockingMarkSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -16596,7 +16596,7 @@
       "HandOfChayulaPlayer",
       "SupportHandOfChayulaPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkHandOfChayula.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkHandOfChayula.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -16632,7 +16632,7 @@
     "grants_skills": [
       "TimeOfNeedPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/TimeOfNeedSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/TimeOfNeedSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16667,7 +16667,7 @@
       "SupportElementalInvocationPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/ElementalInvocationSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/ElementalInvocationSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -16705,7 +16705,7 @@
     "grants_skills": [
       "AttritionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/AttritionSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/AttritionSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -16737,7 +16737,7 @@
     "grants_skills": [
       "ElementalConfluxPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/ElementalConfluxSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/ElementalConfluxSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -16773,7 +16773,7 @@
     "grants_skills": [
       "EmergencyReloadPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MercEmergencyReload.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MercEmergencyReload.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -16805,7 +16805,7 @@
     "grants_skills": [
       "SupportBloodFountainPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FontOfBloodSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FontOfBloodSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16836,7 +16836,7 @@
     "grants_skills": [
       "SupportManaFountainPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ManaFountainSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ManaFountainSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -16867,7 +16867,7 @@
     "grants_skills": [
       "SupportRageFountainPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FontOfRageSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FontOfRageSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16898,7 +16898,7 @@
     "grants_skills": [
       "SupportAftershockChancePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AftershockSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/AftershockSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -16932,7 +16932,7 @@
       "ClusterGrenadePlayer",
       "ClusterGrenadeMiniPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MercClusterGrenade.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MercClusterGrenade.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -16968,7 +16968,7 @@
     "grants_skills": [
       "TornadoShotPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerTornadoShotSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerTornadoShotSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17001,7 +17001,7 @@
     "grants_skills": [
       "BlinkSandPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressBlinkReservation.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressBlinkReservation.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17032,7 +17032,7 @@
     "grants_skills": [
       "ChargeInfusionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/ChargeMasteryDeath.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/ChargeMasteryDeath.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -17064,7 +17064,7 @@
     "grants_skills": [
       "SupportHolyDescentPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/HolyDescentSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/HolyDescentSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17095,7 +17095,7 @@
       "SupportBurningRunesPlayer",
       "TriggeredBurningRunesPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BurningRunesSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/BurningRunesSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -17128,7 +17128,7 @@
     "grants_skills": [
       "ShardScavengerPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MercShardDespoiler.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MercShardDespoiler.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -17164,7 +17164,7 @@
     "grants_skills": [
       "SupportDoubleBarrelPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DoubleBarrelSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/DoubleBarrelSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17194,7 +17194,7 @@
     "grants_skills": [
       "SupportAutoReloadPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AutoReloadSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/AutoReloadSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17224,7 +17224,7 @@
     "grants_skills": [
       "SupportAmmoConservationPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ChanceToNotConsumeAmmoSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ChanceToNotConsumeAmmoSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17254,7 +17254,7 @@
     "grants_skills": [
       "SupportNimbleReloadPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ReloadSpeedSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ReloadSpeedSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17284,7 +17284,7 @@
     "grants_skills": [
       "SupportFreshClipPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DamagePerBoltReloadedRecentlySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/DamagePerBoltReloadedRecentlySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17312,7 +17312,7 @@
     "grants_skills": [
       "SupportSacrificialLambPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/SacrificalLambSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/SacrificalLambSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -17344,7 +17344,7 @@
     "grants_skills": [
       "OverwhelmingPresencePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/OverwhelmingPressureSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/OverwhelmingPressureSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17376,7 +17376,7 @@
     "grants_skills": [
       "AlchemistsBoonPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/AlchemistsBoonSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/AlchemistsBoonSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17411,7 +17411,7 @@
       "SupportReapersInvocationPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MeleeInvocationSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MeleeInvocationSkill.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -17445,7 +17445,7 @@
     "grants_skills": [
       "SacrificePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/HarvesterSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/HarvesterSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -17478,7 +17478,7 @@
     "grants_skills": [
       "ArchmagePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/ArchmageSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/ArchmageSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -17511,7 +17511,7 @@
     "grants_skills": [
       "MagneticSalvoPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerMagneticSalvo.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerMagneticSalvo.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17545,7 +17545,7 @@
     "grants_skills": [
       "FreezingSalvoPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerFreezingSalvoSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerFreezingSalvoSkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17577,7 +17577,7 @@
     "grants_skills": [
       "TriggeredGasCloudPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerGasCloudSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerGasCloudSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17607,7 +17607,7 @@
     "grants_skills": [
       "TriggeredDetonationPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerDetonatingArrowSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerDetonatingArrowSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17638,7 +17638,7 @@
     "grants_skills": [
       "BerserkPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/BeserkSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/BeserkSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17670,7 +17670,7 @@
     "grants_skills": [
       "HeraldOfPlaguePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/HeraldOfAgonySkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/HeraldOfAgonySkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17702,7 +17702,7 @@
     "grants_skills": [
       "HeraldOfBloodPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/iconbasicattack.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/iconbasicattack.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 0,
@@ -17735,7 +17735,7 @@
     "grants_skills": [
       "WitheringPresencePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/WitchWitheringPresence.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/WitchWitheringPresence.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -17769,7 +17769,7 @@
     "grants_skills": [
       "CombatFrenzyPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/RangerCombatFrenzySkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/RangerCombatFrenzySkill.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17801,7 +17801,7 @@
       "SupportMetaCastOnBlockPlayer",
       "SupportInvisibleMetaGemSupport"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/CastOnMeleeBlockSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/CastOnMeleeBlockSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 50,
@@ -17835,7 +17835,7 @@
     "grants_skills": [
       "GatheringStormPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/MonkGatheringStorm.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/MonkGatheringStorm.dds",
     "requirement_weights": {
       "dexterity": 50,
       "intelligence": 50,
@@ -17872,7 +17872,7 @@
     "grants_skills": [
       "SupportUpheavalPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/UpheavalSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/UpheavalSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17904,7 +17904,7 @@
     "grants_skills": [
       "SupportGroundEffectDurationPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/GroundEffectDurationSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/GroundEffectDurationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17934,7 +17934,7 @@
     "grants_skills": [
       "SupportRicochetPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/TerrainChainSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/TerrainChainSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -17965,7 +17965,7 @@
     "grants_skills": [
       "SupportAncestralUrgencyPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/TotemPlacementSpeedSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/TotemPlacementSpeedSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -17996,7 +17996,7 @@
     "grants_skills": [
       "SupportLongFusePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LongFuseSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/LongFuseSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -18027,7 +18027,7 @@
     "grants_skills": [
       "SupportPayloadPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PayloadSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/PayloadSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -18058,7 +18058,7 @@
     "grants_skills": [
       "SupportStripAwayPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/StripAwaySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/StripAwaySupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18089,7 +18089,7 @@
     "grants_skills": [
       "SupportIronwoodPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IronwoodSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/IronwoodSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -18120,7 +18120,7 @@
     "grants_skills": [
       "SupportConsideredCastingPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ConsideredCastingSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ConsideredCastingSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18151,7 +18151,7 @@
     "grants_skills": [
       "SupportWildshardsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/WildshardsSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/WildshardsSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18183,7 +18183,7 @@
     "grants_skills": [
       "SupportIciclePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IceCrystalLessLifeSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/IceCrystalLessLifeSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18213,7 +18213,7 @@
     "grants_skills": [
       "SupportGlacierPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/IceCrystalMoreLifeSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/IceCrystalMoreLifeSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18243,7 +18243,7 @@
     "grants_skills": [
       "SupportHeftPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/HeftSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/HeftSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -18273,7 +18273,7 @@
     "grants_skills": [
       "SupportTempestuousTempoPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/TempestTempoSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/TempestTempoSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18303,7 +18303,7 @@
     "grants_skills": [
       "SupportExtractionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ExtractionSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ExtractionSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18333,7 +18333,7 @@
     "grants_skills": [
       "SupportAstralProjectionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AstralProjectionSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/AstralProjectionSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18363,7 +18363,7 @@
     "grants_skills": [
       "SupportPracticedComboPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PracticedComboSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/PracticedComboSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -18396,7 +18396,7 @@
     "grants_skills": [
       "SupportLeveragePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/LeverageSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/LeverageSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -18426,7 +18426,7 @@
     "grants_skills": [
       "SupportCulminationPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CulminationSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/CulminationSupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -18458,7 +18458,7 @@
     "grants_skills": [
       "SupportPotentialPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/PotentialSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/PotentialSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18488,7 +18488,7 @@
     "grants_skills": [
       "SupportExpansePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ExecrateSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ExecrateSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18519,7 +18519,7 @@
     "grants_skills": [
       "SupportExcisePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ExciseSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ExciseSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18549,7 +18549,7 @@
     "grants_skills": [
       "SupportExecratePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ExpanseSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ExpanseSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18579,7 +18579,7 @@
     "grants_skills": [
       "SupportEnergyRetentionPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/EnergyRetentionSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/EnergyRetentionSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18609,7 +18609,7 @@
     "grants_skills": [
       "SupportFerocityPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/FerocitySupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/FerocitySupport.dds",
     "requirement_weights": {
       "dexterity": 100,
       "intelligence": 0,
@@ -18639,7 +18639,7 @@
     "grants_skills": [
       "SupportAblationPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/AblationSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/AblationSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18669,7 +18669,7 @@
     "grants_skills": [
       "SupportDanseMacabrePlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/DanseMacabreSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/DanseMacabreSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18699,7 +18699,7 @@
     "grants_skills": [
       "SupportCapacitorPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/CapacitorSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/CapacitorSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18729,7 +18729,7 @@
     "grants_skills": [
       "SupportImpetusPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/ImpetusSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/ImpetusSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18759,7 +18759,7 @@
     "grants_skills": [
       "SupportBiddingPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/BiddingSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/BiddingSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18789,7 +18789,7 @@
     "grants_skills": [
       "SupportTremorsPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/Support/UnstableEarthSupport.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/Support/4k/UnstableEarthSupport.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 0,
@@ -18820,7 +18820,7 @@
     "grants_skills": [
       "UniqueDuskVigilTriggeredBlazingClusterPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressBlazingCluster.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressBlazingCluster.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18853,7 +18853,7 @@
     "grants_skills": [
       "UniqueEarthboundTriggeredSparkPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/SorceressSpark.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/SorceressSpark.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18885,7 +18885,7 @@
     "grants_skills": [
       "SupportExpandingGroundPlayer"
     ],
-    "icon_dds_file": "",
+    "icon_dds_file": "4k/",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,
@@ -18913,7 +18913,7 @@
     "grants_skills": [
       "UniqueBreachLightningBoltPlayer"
     ],
-    "icon_dds_file": "Art/2DArt/SkillIcons/GreaterLightningBoltSkill.dds",
+    "icon_dds_file": "Art/2DArt/SkillIcons/4k/GreaterLightningBoltSkill.dds",
     "requirement_weights": {
       "dexterity": 0,
       "intelligence": 100,

--- a/RePoE/parser/poe2/skill_gems.py
+++ b/RePoE/parser/poe2/skill_gems.py
@@ -81,6 +81,8 @@ class skill_gems(Parser_Module):
 
                 skill_gem = convert_gem(gem, gem_effect, support_gem_icons)
                 skill_gems.append(skill_gem)
+                if skill_gem["ui_image"] not in (None, ''):
+                    export_image(skill_gem["ui_image"], self.data_path, self.file_system)
                 if skill_gem["icon_dds_file"] not in (None, ''):
                     export_image(skill_gem["icon_dds_file"], self.data_path, self.file_system)
 

--- a/RePoE/parser/poe2/skill_gems.py
+++ b/RePoE/parser/poe2/skill_gems.py
@@ -56,7 +56,7 @@ def convert_gem(
     if obj["gem_type"] != "support":
         obj["icon_dds_file"] = gem_effect["GrantedEffect"]["ActiveSkill"]["Icon_DDSFile"]
     else:
-        obj["icon_dds_file"] = support_gem_icons[skill_gem.rowid]
+        obj["icon_dds_file"] = support_gem_icons.get(skill_gem.rowid)
 
     return obj
 
@@ -68,7 +68,7 @@ class skill_gems(Parser_Module):
 
         support_gem_icons = {}
         for support in relational_reader["SupportGems.dat64"]:
-            support_gem_icons[support["SkillGem"]] = support["Icon"]
+            support_gem_icons[support["SkillGem"].rowid] = support["Icon"]
 
         # Skills from gems
         for gem in relational_reader["SkillGems.dat64"]:
@@ -79,8 +79,10 @@ class skill_gems(Parser_Module):
                 ):
                     continue
 
-                skill_gems.append(convert_gem(gem, gem_effect, support_gem_icons))
-                export_image(gem["icon_dds_file"], self.data_path, self.file_system)
+                skill_gem = convert_gem(gem, gem_effect, support_gem_icons)
+                skill_gems.append(skill_gem)
+                if skill_gem["icon_dds_file"] not in (None, ''):
+                    export_image(skill_gem["icon_dds_file"], self.data_path, self.file_system)
 
         write_any_json(skill_gems, self.data_path, "skill_gems")
 

--- a/RePoE/parser/poe2/skill_gems.py
+++ b/RePoE/parser/poe2/skill_gems.py
@@ -20,6 +20,13 @@ def _convert_base_item_specific(
     }
 
 
+def get_4k_path(path: str):
+    if path is None:
+        return None
+    parts = path.split('/')
+    parts.insert(len(parts) - 1, '4k')
+    return '/'.join(parts)
+
 def convert_gem(
         skill_gem: DatRecord,
         gem_effect: DatRecord,
@@ -54,12 +61,11 @@ def convert_gem(
     obj["ui_image"] = skill_gem["UI_Image"] or None
 
     if obj["gem_type"] != "support":
-        obj["icon_dds_file"] = gem_effect["GrantedEffect"]["ActiveSkill"]["Icon_DDSFile"]
+        obj["icon_dds_file"] = get_4k_path(gem_effect["GrantedEffect"]["ActiveSkill"]["Icon_DDSFile"])
     else:
-        obj["icon_dds_file"] = support_gem_icons.get(skill_gem.rowid)
+        obj["icon_dds_file"] = get_4k_path(support_gem_icons.get(skill_gem.rowid))
 
     return obj
-
 
 class skill_gems(Parser_Module):
     def write(self) -> None:


### PR DESCRIPTION
This PR captures skill icons in `skill_gems.json` and extracts the images into the `data/poe2` directory.

Note: I am only grabbing the 4k icons, though we could easily include both if that's desirable.

#17 #16 