### PR TITLE
capture fallback skill gem ui image

### DIFF
--- a/RePoE/data/poe2/skill_gems.json
+++ b/RePoE/data/poe2/skill_gems.json
@@ -200,8 +200,7 @@
       "attack",
       "fire"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -231,8 +230,7 @@
       "support",
       "attack"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -262,8 +260,7 @@
       "support",
       "projectile"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -293,8 +290,7 @@
       "support",
       "projectile"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -325,8 +321,7 @@
       "attack",
       "cold"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -356,8 +351,7 @@
       "support",
       "attack"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -387,8 +381,7 @@
       "support",
       "area"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -419,8 +412,7 @@
       "attack",
       "lightning"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -482,8 +474,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -513,8 +504,7 @@
       "support",
       "critical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -543,8 +533,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -575,8 +564,7 @@
       "attack",
       "physical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -607,8 +595,7 @@
       "attack",
       "physical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -639,8 +626,7 @@
       "attack",
       "chaos"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -770,8 +756,7 @@
       "support",
       "projectile"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -899,8 +884,7 @@
       "melee",
       "physical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -930,8 +914,7 @@
       "support",
       "spell"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -1200,8 +1183,7 @@
       "support",
       "area"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -1233,8 +1215,7 @@
       "melee",
       "physical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -1470,8 +1451,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -1569,8 +1549,7 @@
       "support",
       "fire"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -1600,8 +1579,7 @@
       "support",
       "cold"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -1631,8 +1609,7 @@
       "support",
       "lightning"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -1663,8 +1640,7 @@
       "projectile",
       "chaining"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -1694,8 +1670,7 @@
       "support",
       "projectile"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -1867,8 +1842,7 @@
       "spell",
       "area"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -1898,8 +1872,7 @@
       "support",
       "minion"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -1929,8 +1902,7 @@
       "support",
       "projectile"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -2312,8 +2284,7 @@
       "aura",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -2381,8 +2352,7 @@
       "cold",
       "duration"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -2412,8 +2382,7 @@
       "support",
       "cold"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -2443,8 +2412,7 @@
       "support",
       "lightning"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -2715,8 +2683,7 @@
       "spell",
       "critical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -2815,8 +2782,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3151,8 +3117,7 @@
       "area",
       "fire"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3182,8 +3147,7 @@
       "support",
       "physical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3213,8 +3177,7 @@
       "support",
       "chaos"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3244,8 +3207,7 @@
       "support",
       "attack"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3276,8 +3238,7 @@
       "fire",
       "payoff"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3307,8 +3268,7 @@
       "support",
       "lightning"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3338,8 +3298,7 @@
       "support",
       "physical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3368,8 +3327,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3400,8 +3358,7 @@
       "spell",
       "duration"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3467,8 +3424,7 @@
       "chaos",
       "duration"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3530,8 +3486,7 @@
       "support",
       "spell"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3561,8 +3516,7 @@
       "support",
       "attack"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3593,8 +3547,7 @@
       "attack",
       "melee"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3661,8 +3614,7 @@
       "support",
       "minion"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3692,8 +3644,7 @@
       "support",
       "minion"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3725,8 +3676,7 @@
       "area",
       "fire"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3792,8 +3742,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -3962,8 +3911,7 @@
       "trigger",
       "chaos"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -4091,8 +4039,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -4124,8 +4071,7 @@
       "melee",
       "strike"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -4154,8 +4100,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -4285,8 +4230,7 @@
       "support",
       "lightning"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -4590,8 +4534,7 @@
       "persistent",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -5368,8 +5311,7 @@
       "slam",
       "duration"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -5399,8 +5341,7 @@
       "support",
       "critical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -5429,8 +5370,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -5460,8 +5400,7 @@
       "support",
       "duration"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -5493,8 +5432,7 @@
       "melee",
       "slam"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -5523,8 +5461,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -5554,8 +5491,7 @@
       "support",
       "duration"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -5587,8 +5523,7 @@
       "melee",
       "strike"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -5619,8 +5554,7 @@
       "area",
       "curse"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -6204,8 +6138,7 @@
       "area",
       "cold"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -6235,8 +6168,7 @@
       "cold",
       "duration"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -6664,8 +6596,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -6695,8 +6626,7 @@
       "support",
       "lightning"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -6758,8 +6688,7 @@
       "area",
       "lightning"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -6789,8 +6718,7 @@
       "support",
       "cold"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -6849,8 +6777,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -6880,8 +6807,7 @@
       "support",
       "fire"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -6911,8 +6837,7 @@
       "support",
       "fire"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -6942,8 +6867,7 @@
       "support",
       "fire"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -6971,8 +6895,7 @@
       "support",
       "minion"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -7035,8 +6958,7 @@
       "area",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -7072,8 +6994,7 @@
       "lightning",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -7102,8 +7023,7 @@
       "spell",
       "trigger"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -7139,8 +7059,7 @@
       "cold",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -7176,8 +7095,7 @@
       "fire",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -7210,8 +7128,7 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -7244,8 +7161,7 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -7280,8 +7196,7 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -7314,8 +7229,7 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -7348,8 +7262,7 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -7379,8 +7292,7 @@
       "support",
       "payoff"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -7409,8 +7321,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -8663,8 +8574,7 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -8693,8 +8603,7 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -8723,8 +8632,7 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -8753,8 +8661,7 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -8783,8 +8690,7 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -8813,8 +8719,7 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -8843,8 +8748,7 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -8873,8 +8777,7 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -8903,8 +8806,7 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -8940,8 +8842,7 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageBarrierInvocation.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -8976,8 +8877,7 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -9010,8 +8910,7 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -9044,8 +8943,7 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -9075,8 +8973,7 @@
       "support",
       "warcry"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -9270,8 +9167,7 @@
       "persistent",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -9308,8 +9204,7 @@
       "duration",
       "meta"
     ],
-    "tutorial_video": "Art/Videos/SkillTutorials/AncestralWarriorTotem.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageAncestralWarriorTotem.dds"
+    "tutorial_video": "Art/Videos/SkillTutorials/AncestralWarriorTotem.bk2"
   },
   {
     "base_item": {
@@ -9340,8 +9235,7 @@
       "duration",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -9372,8 +9266,7 @@
       "duration",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -9938,8 +9831,7 @@
       "support",
       "cold"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -9969,8 +9861,7 @@
       "support",
       "lightning"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -9998,8 +9889,7 @@
       "support",
       "critical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -10028,8 +9918,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -10060,8 +9949,7 @@
       "physical",
       "chaos"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -10820,8 +10708,7 @@
       "physical",
       "chaos"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -10883,8 +10770,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -10916,8 +10802,7 @@
       "fire",
       "payoff"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -10948,8 +10833,7 @@
       "lightning",
       "fire"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -10978,8 +10862,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11009,8 +10892,7 @@
       "support",
       "lightning"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11074,8 +10956,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11108,8 +10989,7 @@
       "area",
       "trigger"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11140,8 +11020,7 @@
       "cold",
       "payoff"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11177,8 +11056,7 @@
       "fire",
       "payoff"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11207,8 +11085,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11241,8 +11118,7 @@
       "spell",
       "fire"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11496,8 +11372,7 @@
       "support",
       "herald"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11525,8 +11400,7 @@
       "support",
       "buff"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11560,8 +11434,7 @@
       "fire",
       "critical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11591,8 +11464,7 @@
       "support",
       "physical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11621,8 +11493,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11651,8 +11522,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11682,8 +11552,7 @@
       "support",
       "physical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11713,8 +11582,7 @@
       "support",
       "critical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11847,8 +11715,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11877,8 +11744,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11940,8 +11806,7 @@
       "minion",
       "fire"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -11970,8 +11835,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -12001,8 +11865,7 @@
       "support",
       "curse"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -12031,8 +11894,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -12063,8 +11925,7 @@
       "chaos",
       "curse"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -12094,8 +11955,7 @@
       "support",
       "curse"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -12125,8 +11985,7 @@
       "support",
       "curse"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -12156,8 +12015,7 @@
       "support",
       "minion"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -12189,8 +12047,7 @@
       "persistent",
       "duration"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -12219,8 +12076,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -12249,8 +12105,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -12315,8 +12170,7 @@
       "lightning",
       "duration"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -12352,8 +12206,7 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -12383,8 +12236,7 @@
       "support",
       "chaos"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -12413,8 +12265,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -12443,8 +12294,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -12473,8 +12323,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -12736,8 +12585,7 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -13521,8 +13369,7 @@
       "support",
       "warcry"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -13552,8 +13399,7 @@
       "support",
       "spell"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -13582,8 +13428,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -14894,8 +14739,7 @@
       "fire",
       "payoff"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -14929,8 +14773,7 @@
       "area",
       "physical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -14962,8 +14805,7 @@
       "melee",
       "strike"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -14994,8 +14836,7 @@
       "fire",
       "duration"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15026,8 +14867,7 @@
       "lightning",
       "duration"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15059,8 +14899,7 @@
       "duration",
       "critical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15090,8 +14929,7 @@
       "support",
       "chaos"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15121,8 +14959,7 @@
       "support",
       "physical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15154,8 +14991,7 @@
       "physical",
       "duration"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15185,8 +15021,7 @@
       "support",
       "channelling"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15216,8 +15051,7 @@
       "support",
       "fire"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15247,8 +15081,7 @@
       "support",
       "cold"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15278,8 +15111,7 @@
       "support",
       "lightning"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15309,8 +15141,7 @@
       "support",
       "chaos"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15340,8 +15171,7 @@
       "support",
       "physical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15371,8 +15201,7 @@
       "support",
       "minion"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15540,8 +15369,7 @@
       "support",
       "duration"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15572,8 +15400,7 @@
       "spell",
       "duration"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15603,8 +15430,7 @@
       "support",
       "spell"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15635,8 +15461,7 @@
       "spell",
       "chaos"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15667,8 +15492,7 @@
       "spell",
       "chaos"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15696,8 +15520,7 @@
       "support",
       "projectile"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15728,8 +15551,7 @@
       "attack",
       "strike"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15760,8 +15582,7 @@
       "spell",
       "minion"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15792,8 +15613,7 @@
       "buff",
       "persistent"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15824,8 +15644,7 @@
       "buff",
       "persistent"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15856,8 +15675,7 @@
       "buff",
       "persistent"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15888,8 +15706,7 @@
       "buff",
       "persistent"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15920,8 +15737,7 @@
       "buff",
       "persistent"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -15985,8 +15801,7 @@
       "area",
       "chaos"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -16016,8 +15831,7 @@
       "support",
       "physical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -16047,8 +15861,7 @@
       "support",
       "attack"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -16077,8 +15890,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -16107,8 +15919,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -16138,8 +15949,7 @@
       "support",
       "attack"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -16170,8 +15980,7 @@
       "attack",
       "physical"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -16201,8 +16010,7 @@
       "support",
       "attack"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -16232,8 +16040,7 @@
       "support",
       "warcry"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -16262,8 +16069,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -16293,8 +16099,7 @@
       "support",
       "attack"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -16323,8 +16128,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -16614,8 +16418,7 @@
       "chaos",
       "meta"
     ],
-    "tutorial_video": "Art/Videos/SkillTutorials/HandOfChayula.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": "Art/Videos/SkillTutorials/HandOfChayula.bk2"
   },
   {
     "base_item": {
@@ -16686,8 +16489,7 @@
       "fire",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -16818,8 +16620,7 @@
       "support",
       "totem"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -16849,8 +16650,7 @@
       "support",
       "totem"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -16880,8 +16680,7 @@
       "support",
       "totem"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -16913,8 +16712,7 @@
       "melee",
       "slam"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -17076,8 +16874,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -17110,8 +16907,7 @@
       "area",
       "fire"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -17176,8 +16972,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -17206,8 +17001,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -17236,8 +17030,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -17266,8 +17059,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -17296,8 +17088,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -17325,8 +17116,7 @@
       "support",
       "minion"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -17427,8 +17217,7 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -17817,8 +17606,7 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -17886,8 +17674,7 @@
       "attack",
       "melee"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -17916,8 +17703,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -17947,8 +17733,7 @@
       "support",
       "projectile"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -17978,8 +17763,7 @@
       "support",
       "totem"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18009,8 +17793,7 @@
       "support",
       "grenade"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18040,8 +17823,7 @@
       "support",
       "grenade"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18071,8 +17853,7 @@
       "support",
       "spell"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18102,8 +17883,7 @@
       "support",
       "totem"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18133,8 +17913,7 @@
       "support",
       "spell"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18165,8 +17944,7 @@
       "spell",
       "projectile"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18195,8 +17973,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18225,8 +18002,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18255,8 +18031,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18285,8 +18060,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18315,8 +18089,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18345,8 +18118,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18378,8 +18150,7 @@
       "melee",
       "strike"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18408,8 +18179,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18440,8 +18210,7 @@
       "attack",
       "melee"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18470,8 +18239,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18501,8 +18269,7 @@
       "support",
       "area"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18531,8 +18298,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18561,8 +18327,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18591,8 +18356,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18621,8 +18385,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18651,8 +18414,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18681,8 +18443,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18711,8 +18472,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18741,8 +18501,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18771,8 +18530,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18804,8 +18562,7 @@
       "melee",
       "slam"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {
@@ -18897,8 +18654,7 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "tutorial_video": null
   },
   {
     "base_item": {

--- a/RePoE/data/poe2/skill_gems.json
+++ b/RePoE/data/poe2/skill_gems.json
@@ -169,7 +169,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -201,7 +201,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -232,7 +232,7 @@
       "attack"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -263,7 +263,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -294,7 +294,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -326,7 +326,7 @@
       "cold"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -357,7 +357,7 @@
       "attack"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -388,7 +388,7 @@
       "area"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -420,7 +420,7 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -483,7 +483,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -514,7 +514,7 @@
       "critical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -544,7 +544,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -576,7 +576,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -608,7 +608,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -640,7 +640,7 @@
       "chaos"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -740,7 +740,7 @@
       "cold"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -771,7 +771,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -801,7 +801,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -867,7 +867,7 @@
       "nova"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -900,7 +900,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -931,7 +931,7 @@
       "spell"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -965,7 +965,7 @@
       "curse"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/TemporalChains.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -999,7 +999,7 @@
       "curse"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/Enfeeble.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1201,7 +1201,7 @@
       "area"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1234,7 +1234,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1336,7 +1336,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1402,7 +1402,7 @@
       "aura"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1471,7 +1471,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1570,7 +1570,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1601,7 +1601,7 @@
       "cold"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1632,7 +1632,7 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1664,7 +1664,7 @@
       "chaining"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1695,7 +1695,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1730,7 +1730,7 @@
       "curse"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/Flammability.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1765,7 +1765,7 @@
       "curse"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/Hypothermia.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1800,7 +1800,7 @@
       "curse"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/Conductivity.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1836,7 +1836,7 @@
       "channelling"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/Incinerate.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1868,7 +1868,7 @@
       "area"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1899,7 +1899,7 @@
       "minion"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1930,7 +1930,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1962,7 +1962,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -1994,7 +1994,7 @@
       "cold"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -2026,7 +2026,7 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -2129,7 +2129,7 @@
       "lightning"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/BallLightning.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -2238,7 +2238,7 @@
       "payoff"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -2313,7 +2313,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -2382,7 +2382,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -2413,7 +2413,7 @@
       "cold"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -2444,7 +2444,7 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -2650,7 +2650,7 @@
       "channelling"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -2716,7 +2716,7 @@
       "critical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -2816,7 +2816,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -2849,7 +2849,7 @@
       "nova"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3152,7 +3152,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3183,7 +3183,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3214,7 +3214,7 @@
       "chaos"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3245,7 +3245,7 @@
       "attack"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3277,7 +3277,7 @@
       "payoff"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3308,7 +3308,7 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3339,7 +3339,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3369,7 +3369,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3401,7 +3401,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3468,7 +3468,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3500,7 +3500,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3531,7 +3531,7 @@
       "spell"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3562,7 +3562,7 @@
       "attack"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3594,7 +3594,7 @@
       "melee"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3662,7 +3662,7 @@
       "minion"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3693,7 +3693,7 @@
       "minion"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3726,7 +3726,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3763,7 +3763,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/ArtilleryBallista.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3793,7 +3793,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3893,7 +3893,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -3963,7 +3963,7 @@
       "chaos"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4029,7 +4029,7 @@
       "chaining"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4062,7 +4062,7 @@
       "critical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4092,7 +4092,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4125,7 +4125,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4155,7 +4155,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4222,7 +4222,7 @@
       "cold"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/EyeOfWinter.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4255,7 +4255,7 @@
       "orb"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4286,7 +4286,7 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4355,7 +4355,7 @@
       "orb"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4424,7 +4424,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4458,7 +4458,7 @@
       "travel"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4493,7 +4493,7 @@
       "travel"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4525,7 +4525,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4558,7 +4558,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4591,7 +4591,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4654,7 +4654,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4685,7 +4685,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4716,7 +4716,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4885,7 +4885,7 @@
       "slam"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4950,7 +4950,7 @@
       "slam"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -4982,7 +4982,7 @@
       "slam"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5014,7 +5014,7 @@
       "channelling"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5045,7 +5045,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5076,7 +5076,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5107,7 +5107,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5139,7 +5139,7 @@
       "slam"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5170,7 +5170,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5202,7 +5202,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5268,7 +5268,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5299,7 +5299,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5369,7 +5369,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5400,7 +5400,7 @@
       "critical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5430,7 +5430,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5461,7 +5461,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5494,7 +5494,7 @@
       "slam"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5524,7 +5524,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5555,7 +5555,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5588,7 +5588,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5620,7 +5620,7 @@
       "curse"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5720,7 +5720,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5751,7 +5751,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5781,7 +5781,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5813,7 +5813,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5844,7 +5844,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5875,7 +5875,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5906,7 +5906,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5937,7 +5937,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -5969,7 +5969,7 @@
       "nova"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6004,7 +6004,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/RipwireBallista.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6173,7 +6173,7 @@
       "minion"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6205,7 +6205,7 @@
       "cold"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6236,7 +6236,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6266,7 +6266,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6330,7 +6330,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6358,7 +6358,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6388,7 +6388,7 @@
       "melee"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6419,7 +6419,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6451,7 +6451,7 @@
       "cold"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6481,7 +6481,7 @@
       "melee"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6510,7 +6510,7 @@
       "spell"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6540,7 +6540,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6571,7 +6571,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6602,7 +6602,7 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6637,7 +6637,7 @@
       "travel"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6665,7 +6665,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6696,7 +6696,7 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6727,7 +6727,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6759,7 +6759,7 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6790,7 +6790,7 @@
       "cold"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6822,7 +6822,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6850,7 +6850,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6881,7 +6881,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6912,7 +6912,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6943,7 +6943,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -6972,7 +6972,7 @@
       "minion"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7004,7 +7004,7 @@
       "slam"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7036,7 +7036,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7073,7 +7073,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7103,7 +7103,7 @@
       "trigger"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7140,7 +7140,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7177,7 +7177,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7211,7 +7211,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7245,7 +7245,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7281,7 +7281,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7315,7 +7315,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7349,7 +7349,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7380,7 +7380,7 @@
       "payoff"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7410,7 +7410,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7445,7 +7445,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7480,7 +7480,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7515,7 +7515,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7550,7 +7550,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7585,7 +7585,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7620,7 +7620,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7656,7 +7656,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7691,7 +7691,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7726,7 +7726,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7763,7 +7763,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7798,7 +7798,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7835,7 +7835,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7870,7 +7870,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7907,7 +7907,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7942,7 +7942,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -7981,7 +7981,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8016,7 +8016,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8044,7 +8044,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8072,7 +8072,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8100,7 +8100,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8128,7 +8128,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8156,7 +8156,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8184,7 +8184,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8212,7 +8212,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8240,7 +8240,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8268,7 +8268,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8296,7 +8296,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8333,7 +8333,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8370,7 +8370,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8407,7 +8407,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8444,7 +8444,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8481,7 +8481,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8520,7 +8520,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8557,7 +8557,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8594,7 +8594,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8634,7 +8634,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8664,7 +8664,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8694,7 +8694,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8724,7 +8724,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8754,7 +8754,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8784,7 +8784,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8814,7 +8814,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8844,7 +8844,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8874,7 +8874,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8904,7 +8904,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -8977,7 +8977,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9011,7 +9011,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9045,7 +9045,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9076,7 +9076,7 @@
       "warcry"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9110,7 +9110,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9143,7 +9143,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9172,7 +9172,7 @@
       "minion"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9206,7 +9206,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9237,7 +9237,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9271,7 +9271,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9341,7 +9341,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9373,7 +9373,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9410,7 +9410,7 @@
       "detonator"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/ExplosiveGrenade.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9445,7 +9445,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/FlashGrenade.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9481,7 +9481,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/OilGrenade.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9518,7 +9518,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/GasGrenade.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9554,7 +9554,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/VoltaicGrenade.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9801,7 +9801,7 @@
       "chaos"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9939,7 +9939,7 @@
       "cold"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9970,7 +9970,7 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -9999,7 +9999,7 @@
       "critical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -10029,7 +10029,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -10061,7 +10061,7 @@
       "chaos"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -10199,7 +10199,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -10579,7 +10579,7 @@
       "channelling"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -10718,7 +10718,7 @@
       "cold"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -10785,7 +10785,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -10821,7 +10821,7 @@
       "chaos"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -10854,7 +10854,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -10884,7 +10884,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -10917,7 +10917,7 @@
       "payoff"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -10949,7 +10949,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -10979,7 +10979,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11010,7 +11010,7 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11045,7 +11045,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11075,7 +11075,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11109,7 +11109,7 @@
       "trigger"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11141,7 +11141,7 @@
       "payoff"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11178,7 +11178,7 @@
       "payoff"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11208,7 +11208,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11242,7 +11242,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11273,7 +11273,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11304,7 +11304,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11334,7 +11334,7 @@
       "area"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11365,7 +11365,7 @@
       "melee"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11401,7 +11401,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11432,7 +11432,7 @@
       "travel"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11468,7 +11468,7 @@
       "melee"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11497,7 +11497,7 @@
       "herald"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11526,7 +11526,7 @@
       "buff"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11561,7 +11561,7 @@
       "critical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11592,7 +11592,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11622,7 +11622,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11652,7 +11652,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11683,7 +11683,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11714,7 +11714,7 @@
       "critical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11848,7 +11848,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11878,7 +11878,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11909,7 +11909,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11941,7 +11941,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -11971,7 +11971,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12002,7 +12002,7 @@
       "curse"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12032,7 +12032,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12064,7 +12064,7 @@
       "curse"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12095,7 +12095,7 @@
       "curse"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12126,7 +12126,7 @@
       "curse"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12157,7 +12157,7 @@
       "minion"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12190,7 +12190,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12220,7 +12220,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12250,7 +12250,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12283,7 +12283,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12316,7 +12316,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12353,7 +12353,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12384,7 +12384,7 @@
       "chaos"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12414,7 +12414,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12444,7 +12444,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12474,7 +12474,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12508,7 +12508,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12541,7 +12541,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12570,7 +12570,7 @@
       "spell"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12602,7 +12602,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12636,7 +12636,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12670,7 +12670,7 @@
       "fire"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/MoltenBlast.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12703,7 +12703,7 @@
       "critical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12737,7 +12737,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12772,7 +12772,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/HammerOfTheGods.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12804,7 +12804,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12840,7 +12840,7 @@
       "travel"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/Stampede.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12874,7 +12874,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/ShieldWall.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12910,7 +12910,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12945,7 +12945,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/EmberFusillade.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -12981,7 +12981,7 @@
       "payoff"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/HighVelocityRounds.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13016,7 +13016,7 @@
       "payoff"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/FragmentationRounds.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13054,7 +13054,7 @@
       "payoff"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/SiegeCascade.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13089,7 +13089,7 @@
       "physical"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/ArmourPiercingRounds.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13126,7 +13126,7 @@
       "detonator"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/ExplosiveShot.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13162,7 +13162,7 @@
       "fire"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/IncendiaryShot.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13197,7 +13197,7 @@
       "fire"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/RapidShot.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13234,7 +13234,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/GlacialBolt.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13270,7 +13270,7 @@
       "cold"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/PermafrostBolts.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13307,7 +13307,7 @@
       "cold"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/HailstormRounds.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13344,7 +13344,7 @@
       "cold"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/IceShards.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13381,7 +13381,7 @@
       "channelling"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/PlasmaBlast.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13417,7 +13417,7 @@
       "chaining"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/GalvanicShards.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13454,7 +13454,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/StormblastBolts.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13491,7 +13491,7 @@
       "payoff"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/ShockburstRounds.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13522,7 +13522,7 @@
       "warcry"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13553,7 +13553,7 @@
       "spell"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13583,7 +13583,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13615,7 +13615,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13647,7 +13647,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13679,7 +13679,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13711,7 +13711,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13743,7 +13743,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13775,7 +13775,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13807,7 +13807,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13839,7 +13839,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13871,7 +13871,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13903,7 +13903,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13935,7 +13935,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13967,7 +13967,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -13999,7 +13999,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14031,7 +14031,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14063,7 +14063,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14095,7 +14095,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14127,7 +14127,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14157,7 +14157,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14188,7 +14188,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14220,7 +14220,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14253,7 +14253,7 @@
       "travel"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14285,7 +14285,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14315,7 +14315,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14348,7 +14348,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14381,7 +14381,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14414,7 +14414,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14446,7 +14446,7 @@
       "chaos"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14478,7 +14478,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14508,7 +14508,7 @@
       "channelling"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14544,7 +14544,7 @@
       "orb"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14577,7 +14577,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14608,7 +14608,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14639,7 +14639,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14670,7 +14670,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14699,7 +14699,7 @@
       "spell"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14732,7 +14732,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14763,7 +14763,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14797,7 +14797,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14827,7 +14827,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14858,7 +14858,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14895,7 +14895,7 @@
       "payoff"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14930,7 +14930,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14963,7 +14963,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -14995,7 +14995,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15027,7 +15027,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15060,7 +15060,7 @@
       "critical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15091,7 +15091,7 @@
       "chaos"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15122,7 +15122,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15155,7 +15155,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15186,7 +15186,7 @@
       "channelling"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15217,7 +15217,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15248,7 +15248,7 @@
       "cold"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15279,7 +15279,7 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15310,7 +15310,7 @@
       "chaos"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15341,7 +15341,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15372,7 +15372,7 @@
       "minion"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15408,7 +15408,7 @@
       "payoff"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/ShockchainArrow.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15443,7 +15443,7 @@
       "travel"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/VaultingImpact.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15477,7 +15477,7 @@
       "lightning"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/StormWave.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15510,7 +15510,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/MantraOfDestruction.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15541,7 +15541,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15573,7 +15573,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15604,7 +15604,7 @@
       "spell"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15636,7 +15636,7 @@
       "chaos"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15668,7 +15668,7 @@
       "chaos"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15697,7 +15697,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15729,7 +15729,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15761,7 +15761,7 @@
       "minion"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15793,7 +15793,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15825,7 +15825,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15857,7 +15857,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15889,7 +15889,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15921,7 +15921,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15954,7 +15954,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -15986,7 +15986,7 @@
       "chaos"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16017,7 +16017,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16048,7 +16048,7 @@
       "attack"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16078,7 +16078,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16108,7 +16108,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16139,7 +16139,7 @@
       "attack"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16171,7 +16171,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16202,7 +16202,7 @@
       "attack"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16233,7 +16233,7 @@
       "warcry"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16263,7 +16263,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16294,7 +16294,7 @@
       "attack"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16324,7 +16324,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16360,7 +16360,7 @@
       "chaining"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16393,7 +16393,7 @@
       "cold"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/IceShot.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16429,7 +16429,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16465,7 +16465,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16502,7 +16502,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16540,7 +16540,7 @@
       "nova"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/FreezingMark.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16578,7 +16578,7 @@
       "nova"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/VoltaicMark.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16615,7 +16615,7 @@
       "meta"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/HandOfChayula.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16648,7 +16648,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16687,7 +16687,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16720,7 +16720,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16756,7 +16756,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16788,7 +16788,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/EmergencyReload.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16819,7 +16819,7 @@
       "totem"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16850,7 +16850,7 @@
       "totem"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16881,7 +16881,7 @@
       "totem"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16914,7 +16914,7 @@
       "slam"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16951,7 +16951,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/ClusterGrenade.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -16986,7 +16986,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/TornadoShot.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17015,7 +17015,7 @@
       "spell"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17047,7 +17047,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17077,7 +17077,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17111,7 +17111,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17147,7 +17147,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17177,7 +17177,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17207,7 +17207,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17237,7 +17237,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17267,7 +17267,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17297,7 +17297,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17326,7 +17326,7 @@
       "minion"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17359,7 +17359,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17392,7 +17392,7 @@
       "aura"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17428,7 +17428,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17461,7 +17461,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17494,7 +17494,7 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17528,7 +17528,7 @@
       "lightning"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/MagneticSalvo.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17562,7 +17562,7 @@
       "cold"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/FreezingSalvo.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17592,7 +17592,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17621,7 +17621,7 @@
       "area"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17653,7 +17653,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17687,7 +17687,7 @@
       "herald"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17718,7 +17718,7 @@
       "herald"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17752,7 +17752,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17784,7 +17784,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17818,7 +17818,7 @@
       "meta"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17855,7 +17855,7 @@
       "travel"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/GatheringStorm.bk2",
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17887,7 +17887,7 @@
       "melee"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17917,7 +17917,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17948,7 +17948,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -17979,7 +17979,7 @@
       "totem"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18010,7 +18010,7 @@
       "grenade"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18041,7 +18041,7 @@
       "grenade"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18072,7 +18072,7 @@
       "spell"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18103,7 +18103,7 @@
       "totem"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18134,7 +18134,7 @@
       "spell"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18166,7 +18166,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18196,7 +18196,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18226,7 +18226,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18256,7 +18256,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18286,7 +18286,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18316,7 +18316,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18346,7 +18346,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18379,7 +18379,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18409,7 +18409,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18441,7 +18441,7 @@
       "melee"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18471,7 +18471,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18502,7 +18502,7 @@
       "area"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18532,7 +18532,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18562,7 +18562,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18592,7 +18592,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18622,7 +18622,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18652,7 +18652,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18682,7 +18682,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18712,7 +18712,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18742,7 +18742,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18772,7 +18772,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18805,7 +18805,7 @@
       "slam"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18838,7 +18838,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18870,7 +18870,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18898,7 +18898,7 @@
       "support"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   },
   {
     "base_item": {
@@ -18929,6 +18929,6 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": null
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
   }
 ]

--- a/RePoE/data/poe2/skill_gems.json
+++ b/RePoE/data/poe2/skill_gems.json
@@ -169,7 +169,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -200,7 +200,8 @@
       "attack",
       "fire"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -230,7 +231,8 @@
       "support",
       "attack"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -260,7 +262,8 @@
       "support",
       "projectile"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -290,7 +293,8 @@
       "support",
       "projectile"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -321,7 +325,8 @@
       "attack",
       "cold"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -351,7 +356,8 @@
       "support",
       "attack"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -381,7 +387,8 @@
       "support",
       "area"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -412,7 +419,8 @@
       "attack",
       "lightning"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -474,7 +482,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -504,7 +513,8 @@
       "support",
       "critical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -533,7 +543,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -564,7 +575,8 @@
       "attack",
       "physical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -595,7 +607,8 @@
       "attack",
       "physical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -626,7 +639,8 @@
       "attack",
       "chaos"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -726,7 +740,7 @@
       "cold"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -756,7 +770,8 @@
       "support",
       "projectile"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -786,7 +801,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -852,7 +867,7 @@
       "nova"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -884,7 +899,8 @@
       "melee",
       "physical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -914,7 +930,8 @@
       "support",
       "spell"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -948,7 +965,7 @@
       "curse"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/TemporalChains.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -982,7 +999,7 @@
       "curse"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/Enfeeble.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1183,7 +1200,8 @@
       "support",
       "area"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1215,7 +1233,8 @@
       "melee",
       "physical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1317,7 +1336,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1383,7 +1402,7 @@
       "aura"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1451,7 +1470,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1549,7 +1569,8 @@
       "support",
       "fire"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1579,7 +1600,8 @@
       "support",
       "cold"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1609,7 +1631,8 @@
       "support",
       "lightning"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1640,7 +1663,8 @@
       "projectile",
       "chaining"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1670,7 +1694,8 @@
       "support",
       "projectile"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1705,7 +1730,7 @@
       "curse"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/Flammability.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1740,7 +1765,7 @@
       "curse"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/Hypothermia.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1775,7 +1800,7 @@
       "curse"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/Conductivity.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1811,7 +1836,7 @@
       "channelling"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/Incinerate.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1842,7 +1867,8 @@
       "spell",
       "area"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1872,7 +1898,8 @@
       "support",
       "minion"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1902,7 +1929,8 @@
       "support",
       "projectile"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1934,7 +1962,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1966,7 +1994,7 @@
       "cold"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -1998,7 +2026,7 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -2101,7 +2129,7 @@
       "lightning"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/BallLightning.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -2210,7 +2238,7 @@
       "payoff"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -2284,7 +2312,8 @@
       "aura",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -2352,7 +2381,8 @@
       "cold",
       "duration"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -2382,7 +2412,8 @@
       "support",
       "cold"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -2412,7 +2443,8 @@
       "support",
       "lightning"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -2618,7 +2650,7 @@
       "channelling"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -2683,7 +2715,8 @@
       "spell",
       "critical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -2782,7 +2815,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -2815,7 +2849,7 @@
       "nova"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3117,7 +3151,8 @@
       "area",
       "fire"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3147,7 +3182,8 @@
       "support",
       "physical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3177,7 +3213,8 @@
       "support",
       "chaos"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3207,7 +3244,8 @@
       "support",
       "attack"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3238,7 +3276,8 @@
       "fire",
       "payoff"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3268,7 +3307,8 @@
       "support",
       "lightning"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3298,7 +3338,8 @@
       "support",
       "physical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3327,7 +3368,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3358,7 +3400,8 @@
       "spell",
       "duration"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3424,7 +3467,8 @@
       "chaos",
       "duration"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3456,7 +3500,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3486,7 +3530,8 @@
       "support",
       "spell"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3516,7 +3561,8 @@
       "support",
       "attack"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3547,7 +3593,8 @@
       "attack",
       "melee"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3614,7 +3661,8 @@
       "support",
       "minion"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3644,7 +3692,8 @@
       "support",
       "minion"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3676,7 +3725,8 @@
       "area",
       "fire"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3713,7 +3763,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/ArtilleryBallista.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3742,7 +3792,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3842,7 +3893,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3911,7 +3962,8 @@
       "trigger",
       "chaos"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -3977,7 +4029,7 @@
       "chaining"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4010,7 +4062,7 @@
       "critical"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4039,7 +4091,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4071,7 +4124,8 @@
       "melee",
       "strike"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4100,7 +4154,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4167,7 +4222,7 @@
       "cold"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/EyeOfWinter.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4200,7 +4255,7 @@
       "orb"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4230,7 +4285,8 @@
       "support",
       "lightning"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4299,7 +4355,7 @@
       "orb"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4368,7 +4424,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4402,7 +4458,7 @@
       "travel"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4437,7 +4493,7 @@
       "travel"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4469,7 +4525,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4502,7 +4558,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4534,7 +4590,8 @@
       "persistent",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4597,7 +4654,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4628,7 +4685,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4659,7 +4716,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4828,7 +4885,7 @@
       "slam"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4893,7 +4950,7 @@
       "slam"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4925,7 +4982,7 @@
       "slam"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4957,7 +5014,7 @@
       "channelling"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -4988,7 +5045,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5019,7 +5076,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5050,7 +5107,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5082,7 +5139,7 @@
       "slam"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5113,7 +5170,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5145,7 +5202,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5211,7 +5268,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5242,7 +5299,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5311,7 +5368,8 @@
       "slam",
       "duration"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5341,7 +5399,8 @@
       "support",
       "critical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5370,7 +5429,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5400,7 +5460,8 @@
       "support",
       "duration"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5432,7 +5493,8 @@
       "melee",
       "slam"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5461,7 +5523,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5491,7 +5554,8 @@
       "support",
       "duration"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5523,7 +5587,8 @@
       "melee",
       "strike"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5554,7 +5619,8 @@
       "area",
       "curse"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5654,7 +5720,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5685,7 +5751,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5715,7 +5781,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5747,7 +5813,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5778,7 +5844,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5809,7 +5875,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5840,7 +5906,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5871,7 +5937,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5903,7 +5969,7 @@
       "nova"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -5938,7 +6004,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/RipwireBallista.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6107,7 +6173,7 @@
       "minion"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6138,7 +6204,8 @@
       "area",
       "cold"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6168,7 +6235,8 @@
       "cold",
       "duration"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6198,7 +6266,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6262,7 +6330,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6290,7 +6358,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6320,7 +6388,7 @@
       "melee"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6351,7 +6419,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6383,7 +6451,7 @@
       "cold"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6413,7 +6481,7 @@
       "melee"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6442,7 +6510,7 @@
       "spell"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6472,7 +6540,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6503,7 +6571,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6534,7 +6602,7 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6569,7 +6637,7 @@
       "travel"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6596,7 +6664,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6626,7 +6695,8 @@
       "support",
       "lightning"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6657,7 +6727,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6688,7 +6758,8 @@
       "area",
       "lightning"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6718,7 +6789,8 @@
       "support",
       "cold"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6750,7 +6822,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6777,7 +6849,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6807,7 +6880,8 @@
       "support",
       "fire"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6837,7 +6911,8 @@
       "support",
       "fire"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6867,7 +6942,8 @@
       "support",
       "fire"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6895,7 +6971,8 @@
       "support",
       "minion"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6927,7 +7004,7 @@
       "slam"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6958,7 +7035,8 @@
       "area",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -6994,7 +7072,8 @@
       "lightning",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7023,7 +7102,8 @@
       "spell",
       "trigger"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7059,7 +7139,8 @@
       "cold",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7095,7 +7176,8 @@
       "fire",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7128,7 +7210,8 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7161,7 +7244,8 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7196,7 +7280,8 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7229,7 +7314,8 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7262,7 +7348,8 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7292,7 +7379,8 @@
       "support",
       "payoff"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7321,7 +7409,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7356,7 +7445,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7391,7 +7480,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7426,7 +7515,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7461,7 +7550,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7496,7 +7585,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7531,7 +7620,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7567,7 +7656,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7602,7 +7691,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7637,7 +7726,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7674,7 +7763,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7709,7 +7798,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7746,7 +7835,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7781,7 +7870,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7818,7 +7907,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7853,7 +7942,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7892,7 +7981,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7927,7 +8016,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7955,7 +8044,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -7983,7 +8072,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8011,7 +8100,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8039,7 +8128,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8067,7 +8156,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8095,7 +8184,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8123,7 +8212,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8151,7 +8240,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8179,7 +8268,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8207,7 +8296,7 @@
       "grants_active_skill"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8244,7 +8333,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8281,7 +8370,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8318,7 +8407,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8355,7 +8444,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8392,7 +8481,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8431,7 +8520,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8468,7 +8557,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8505,7 +8594,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8545,7 +8634,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8574,7 +8663,8 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8603,7 +8693,8 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8632,7 +8723,8 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8661,7 +8753,8 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8690,7 +8783,8 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8719,7 +8813,8 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8748,7 +8843,8 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8777,7 +8873,8 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8806,7 +8903,8 @@
     "tags": [
       "grants_active_skill"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8842,7 +8940,8 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageBarrierInvocation.dds"
   },
   {
     "base_item": {
@@ -8877,7 +8976,8 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8910,7 +9010,8 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8943,7 +9044,8 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -8973,7 +9075,8 @@
       "support",
       "warcry"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9007,7 +9110,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9040,7 +9143,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9069,7 +9172,7 @@
       "minion"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9103,7 +9206,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9134,7 +9237,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9167,7 +9270,8 @@
       "persistent",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9204,7 +9308,8 @@
       "duration",
       "meta"
     ],
-    "tutorial_video": "Art/Videos/SkillTutorials/AncestralWarriorTotem.bk2"
+    "tutorial_video": "Art/Videos/SkillTutorials/AncestralWarriorTotem.bk2",
+    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageAncestralWarriorTotem.dds"
   },
   {
     "base_item": {
@@ -9235,7 +9340,8 @@
       "duration",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9266,7 +9372,8 @@
       "duration",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9303,7 +9410,7 @@
       "detonator"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/ExplosiveGrenade.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9338,7 +9445,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/FlashGrenade.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9374,7 +9481,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/OilGrenade.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9411,7 +9518,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/GasGrenade.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9447,7 +9554,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/VoltaicGrenade.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9694,7 +9801,7 @@
       "chaos"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9831,7 +9938,8 @@
       "support",
       "cold"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9861,7 +9969,8 @@
       "support",
       "lightning"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9889,7 +9998,8 @@
       "support",
       "critical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9918,7 +10028,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -9949,7 +10060,8 @@
       "physical",
       "chaos"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -10087,7 +10199,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -10467,7 +10579,7 @@
       "channelling"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -10606,7 +10718,7 @@
       "cold"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -10673,7 +10785,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -10708,7 +10820,8 @@
       "physical",
       "chaos"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -10741,7 +10854,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -10770,7 +10883,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -10802,7 +10916,8 @@
       "fire",
       "payoff"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -10833,7 +10948,8 @@
       "lightning",
       "fire"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -10862,7 +10978,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -10892,7 +11009,8 @@
       "support",
       "lightning"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -10927,7 +11045,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -10956,7 +11074,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -10989,7 +11108,8 @@
       "area",
       "trigger"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11020,7 +11140,8 @@
       "cold",
       "payoff"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11056,7 +11177,8 @@
       "fire",
       "payoff"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11085,7 +11207,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11118,7 +11241,8 @@
       "spell",
       "fire"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11149,7 +11273,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11180,7 +11304,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11210,7 +11334,7 @@
       "area"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11241,7 +11365,7 @@
       "melee"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11277,7 +11401,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11308,7 +11432,7 @@
       "travel"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11344,7 +11468,7 @@
       "melee"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11372,7 +11496,8 @@
       "support",
       "herald"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11400,7 +11525,8 @@
       "support",
       "buff"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11434,7 +11560,8 @@
       "fire",
       "critical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11464,7 +11591,8 @@
       "support",
       "physical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11493,7 +11621,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11522,7 +11651,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11552,7 +11682,8 @@
       "support",
       "physical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11582,7 +11713,8 @@
       "support",
       "critical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11715,7 +11847,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11744,7 +11877,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11775,7 +11909,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11806,7 +11940,8 @@
       "minion",
       "fire"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11835,7 +11970,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11865,7 +12001,8 @@
       "support",
       "curse"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11894,7 +12031,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11925,7 +12063,8 @@
       "chaos",
       "curse"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11955,7 +12094,8 @@
       "support",
       "curse"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -11985,7 +12125,8 @@
       "support",
       "curse"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12015,7 +12156,8 @@
       "support",
       "minion"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12047,7 +12189,8 @@
       "persistent",
       "duration"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12076,7 +12219,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12105,7 +12249,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12138,7 +12283,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12170,7 +12315,8 @@
       "lightning",
       "duration"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12206,7 +12352,8 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12236,7 +12383,8 @@
       "support",
       "chaos"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12265,7 +12413,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12294,7 +12443,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12323,7 +12473,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12357,7 +12508,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12390,7 +12541,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12419,7 +12570,7 @@
       "spell"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12451,7 +12602,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12485,7 +12636,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12519,7 +12670,7 @@
       "fire"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/MoltenBlast.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12552,7 +12703,7 @@
       "critical"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12585,7 +12736,8 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12620,7 +12772,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/HammerOfTheGods.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12652,7 +12804,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12688,7 +12840,7 @@
       "travel"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/Stampede.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12722,7 +12874,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/ShieldWall.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12758,7 +12910,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12793,7 +12945,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/EmberFusillade.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12829,7 +12981,7 @@
       "payoff"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/HighVelocityRounds.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12864,7 +13016,7 @@
       "payoff"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/FragmentationRounds.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12902,7 +13054,7 @@
       "payoff"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/SiegeCascade.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12937,7 +13089,7 @@
       "physical"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/ArmourPiercingRounds.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -12974,7 +13126,7 @@
       "detonator"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/ExplosiveShot.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13010,7 +13162,7 @@
       "fire"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/IncendiaryShot.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13045,7 +13197,7 @@
       "fire"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/RapidShot.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13082,7 +13234,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/GlacialBolt.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13118,7 +13270,7 @@
       "cold"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/PermafrostBolts.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13155,7 +13307,7 @@
       "cold"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/HailstormRounds.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13192,7 +13344,7 @@
       "cold"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/IceShards.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13229,7 +13381,7 @@
       "channelling"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/PlasmaBlast.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13265,7 +13417,7 @@
       "chaining"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/GalvanicShards.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13302,7 +13454,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/StormblastBolts.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13339,7 +13491,7 @@
       "payoff"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/ShockburstRounds.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13369,7 +13521,8 @@
       "support",
       "warcry"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13399,7 +13552,8 @@
       "support",
       "spell"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13428,7 +13582,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13460,7 +13615,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13492,7 +13647,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13524,7 +13679,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13556,7 +13711,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13588,7 +13743,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13620,7 +13775,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13652,7 +13807,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13684,7 +13839,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13716,7 +13871,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13748,7 +13903,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13780,7 +13935,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13812,7 +13967,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13844,7 +13999,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13876,7 +14031,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13908,7 +14063,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13940,7 +14095,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -13972,7 +14127,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14002,7 +14157,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14033,7 +14188,7 @@
       "projectile"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14065,7 +14220,7 @@
       "strike"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14098,7 +14253,7 @@
       "travel"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14130,7 +14285,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14160,7 +14315,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14193,7 +14348,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14226,7 +14381,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14259,7 +14414,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14291,7 +14446,7 @@
       "chaos"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14323,7 +14478,7 @@
       "physical"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14353,7 +14508,7 @@
       "channelling"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14389,7 +14544,7 @@
       "orb"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14422,7 +14577,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14453,7 +14608,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14484,7 +14639,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14515,7 +14670,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14544,7 +14699,7 @@
       "spell"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14577,7 +14732,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14608,7 +14763,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14642,7 +14797,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14672,7 +14827,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14703,7 +14858,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14739,7 +14894,8 @@
       "fire",
       "payoff"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14773,7 +14929,8 @@
       "area",
       "physical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14805,7 +14962,8 @@
       "melee",
       "strike"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14836,7 +14994,8 @@
       "fire",
       "duration"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14867,7 +15026,8 @@
       "lightning",
       "duration"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14899,7 +15059,8 @@
       "duration",
       "critical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14929,7 +15090,8 @@
       "support",
       "chaos"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14959,7 +15121,8 @@
       "support",
       "physical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -14991,7 +15154,8 @@
       "physical",
       "duration"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15021,7 +15185,8 @@
       "support",
       "channelling"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15051,7 +15216,8 @@
       "support",
       "fire"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15081,7 +15247,8 @@
       "support",
       "cold"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15111,7 +15278,8 @@
       "support",
       "lightning"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15141,7 +15309,8 @@
       "support",
       "chaos"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15171,7 +15340,8 @@
       "support",
       "physical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15201,7 +15371,8 @@
       "support",
       "minion"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15237,7 +15408,7 @@
       "payoff"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/ShockchainArrow.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15272,7 +15443,7 @@
       "travel"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/VaultingImpact.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15306,7 +15477,7 @@
       "lightning"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/StormWave.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15339,7 +15510,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/MantraOfDestruction.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15369,7 +15540,8 @@
       "support",
       "duration"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15400,7 +15572,8 @@
       "spell",
       "duration"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15430,7 +15603,8 @@
       "support",
       "spell"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15461,7 +15635,8 @@
       "spell",
       "chaos"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15492,7 +15667,8 @@
       "spell",
       "chaos"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15520,7 +15696,8 @@
       "support",
       "projectile"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15551,7 +15728,8 @@
       "attack",
       "strike"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15582,7 +15760,8 @@
       "spell",
       "minion"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15613,7 +15792,8 @@
       "buff",
       "persistent"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15644,7 +15824,8 @@
       "buff",
       "persistent"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15675,7 +15856,8 @@
       "buff",
       "persistent"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15706,7 +15888,8 @@
       "buff",
       "persistent"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15737,7 +15920,8 @@
       "buff",
       "persistent"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15770,7 +15954,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15801,7 +15985,8 @@
       "area",
       "chaos"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15831,7 +16016,8 @@
       "support",
       "physical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15861,7 +16047,8 @@
       "support",
       "attack"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15890,7 +16077,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15919,7 +16107,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15949,7 +16138,8 @@
       "support",
       "attack"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -15980,7 +16170,8 @@
       "attack",
       "physical"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16010,7 +16201,8 @@
       "support",
       "attack"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16040,7 +16232,8 @@
       "support",
       "warcry"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16069,7 +16262,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16099,7 +16293,8 @@
       "support",
       "attack"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16128,7 +16323,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16164,7 +16360,7 @@
       "chaining"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16197,7 +16393,7 @@
       "cold"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/IceShot.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16233,7 +16429,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16269,7 +16465,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16306,7 +16502,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16344,7 +16540,7 @@
       "nova"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/FreezingMark.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16382,7 +16578,7 @@
       "nova"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/VoltaicMark.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16418,7 +16614,8 @@
       "chaos",
       "meta"
     ],
-    "tutorial_video": "Art/Videos/SkillTutorials/HandOfChayula.bk2"
+    "tutorial_video": "Art/Videos/SkillTutorials/HandOfChayula.bk2",
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16451,7 +16648,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16489,7 +16686,8 @@
       "fire",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16522,7 +16720,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16558,7 +16756,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16590,7 +16788,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/EmergencyReload.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16620,7 +16818,8 @@
       "support",
       "totem"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16650,7 +16849,8 @@
       "support",
       "totem"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16680,7 +16880,8 @@
       "support",
       "totem"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16712,7 +16913,8 @@
       "melee",
       "slam"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16749,7 +16951,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/ClusterGrenade.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16784,7 +16986,7 @@
       "duration"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/TornadoShot.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16813,7 +17015,7 @@
       "spell"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16845,7 +17047,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16874,7 +17076,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16907,7 +17110,8 @@
       "area",
       "fire"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16943,7 +17147,7 @@
       "fire"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -16972,7 +17176,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17001,7 +17206,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17030,7 +17236,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17059,7 +17266,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17088,7 +17296,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17116,7 +17325,8 @@
       "support",
       "minion"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17149,7 +17359,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17182,7 +17392,7 @@
       "aura"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17217,7 +17427,8 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17250,7 +17461,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17283,7 +17494,7 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17317,7 +17528,7 @@
       "lightning"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/MagneticSalvo.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17351,7 +17562,7 @@
       "cold"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/FreezingSalvo.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17381,7 +17592,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17410,7 +17621,7 @@
       "area"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17442,7 +17653,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17476,7 +17687,7 @@
       "herald"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17507,7 +17718,7 @@
       "herald"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17541,7 +17752,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17573,7 +17784,7 @@
       "persistent"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17606,7 +17817,8 @@
       "trigger",
       "meta"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17643,7 +17855,7 @@
       "travel"
     ],
     "tutorial_video": "Art/Videos/SkillTutorials/GatheringStorm.bk2",
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17674,7 +17886,8 @@
       "attack",
       "melee"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17703,7 +17916,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17733,7 +17947,8 @@
       "support",
       "projectile"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17763,7 +17978,8 @@
       "support",
       "totem"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17793,7 +18009,8 @@
       "support",
       "grenade"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17823,7 +18040,8 @@
       "support",
       "grenade"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17853,7 +18071,8 @@
       "support",
       "spell"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17883,7 +18102,8 @@
       "support",
       "totem"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17913,7 +18133,8 @@
       "support",
       "spell"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17944,7 +18165,8 @@
       "spell",
       "projectile"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -17973,7 +18195,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18002,7 +18225,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18031,7 +18255,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18060,7 +18285,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18089,7 +18315,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18118,7 +18345,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18150,7 +18378,8 @@
       "melee",
       "strike"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18179,7 +18408,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18210,7 +18440,8 @@
       "attack",
       "melee"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18239,7 +18470,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18269,7 +18501,8 @@
       "support",
       "area"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18298,7 +18531,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18327,7 +18561,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18356,7 +18591,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18385,7 +18621,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18414,7 +18651,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18443,7 +18681,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18472,7 +18711,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18501,7 +18741,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18530,7 +18771,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18562,7 +18804,8 @@
       "melee",
       "slam"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18595,7 +18838,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18627,7 +18870,7 @@
       "duration"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18654,7 +18897,8 @@
     "tags": [
       "support"
     ],
-    "tutorial_video": null
+    "tutorial_video": null,
+    "ui_image": null
   },
   {
     "base_item": {
@@ -18685,6 +18929,6 @@
       "lightning"
     ],
     "tutorial_video": null,
-    "ui_image": "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    "ui_image": null
   }
 ]

--- a/RePoE/parser/poe2/skill_gems.py
+++ b/RePoE/parser/poe2/skill_gems.py
@@ -58,7 +58,7 @@ def convert_gem(
     obj["crafting_level"] = skill_gem["CraftingLevel"]
 
     obj["tutorial_video"] = skill_gem["TutorialVideo"] or None
-    obj["ui_image"] = skill_gem["UI_Image"] or None
+    obj["ui_image"] = skill_gem["UI_Image"] or "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
 
     if obj["gem_type"] != "support":
         obj["icon_dds_file"] = get_4k_path(gem_effect["GrantedEffect"]["ActiveSkill"]["Icon_DDSFile"])

--- a/RePoE/parser/poe2/skill_gems.py
+++ b/RePoE/parser/poe2/skill_gems.py
@@ -58,8 +58,7 @@ def convert_gem(
     obj["crafting_level"] = skill_gem["CraftingLevel"]
 
     obj["tutorial_video"] = skill_gem["TutorialVideo"] or None
-    if obj["gem_type"] != "support":
-        obj["ui_image"] = skill_gem["UI_Image"] or "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    obj["ui_image"] = skill_gem["UI_Image"] or "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
 
     if obj["gem_type"] != "support":
         obj["icon_dds_file"] = get_4k_path(gem_effect["GrantedEffect"]["ActiveSkill"]["Icon_DDSFile"])

--- a/RePoE/parser/poe2/skill_gems.py
+++ b/RePoE/parser/poe2/skill_gems.py
@@ -58,7 +58,8 @@ def convert_gem(
     obj["crafting_level"] = skill_gem["CraftingLevel"]
 
     obj["tutorial_video"] = skill_gem["TutorialVideo"] or None
-    obj["ui_image"] = skill_gem["UI_Image"] or "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    if obj["gem_type"] != "support":
+        obj["ui_image"] = skill_gem["UI_Image"] or "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
 
     if obj["gem_type"] != "support":
         obj["icon_dds_file"] = get_4k_path(gem_effect["GrantedEffect"]["ActiveSkill"]["Icon_DDSFile"])
@@ -87,7 +88,7 @@ class skill_gems(Parser_Module):
 
                 skill_gem = convert_gem(gem, gem_effect, support_gem_icons)
                 skill_gems.append(skill_gem)
-                if skill_gem["ui_image"] not in (None, ''):
+                if skill_gem.get("ui_image", None) not in (None, ''):
                     export_image(skill_gem["ui_image"], self.data_path, self.file_system)
                 if skill_gem["icon_dds_file"] not in (None, ''):
                     export_image(skill_gem["icon_dds_file"], self.data_path, self.file_system)

--- a/RePoE/parser/poe2/skill_gems.py
+++ b/RePoE/parser/poe2/skill_gems.py
@@ -58,7 +58,7 @@ def convert_gem(
     obj["crafting_level"] = skill_gem["CraftingLevel"]
 
     obj["tutorial_video"] = skill_gem["TutorialVideo"] or None
-    obj["ui_image"] = skill_gem["UI_Image"] or "Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds"
+    obj["ui_image"] = skill_gem["UI_Image"] or None
 
     if obj["gem_type"] != "support":
         obj["icon_dds_file"] = get_4k_path(gem_effect["GrantedEffect"]["ActiveSkill"]["Icon_DDSFile"])
@@ -87,6 +87,8 @@ class skill_gems(Parser_Module):
 
                 skill_gem = convert_gem(gem, gem_effect, support_gem_icons)
                 skill_gems.append(skill_gem)
+                # ensure fallback ui image is exported without having to add it to gem data
+                export_image("Art/Textures/Interface/2D/2DArt/UIImages/InGame/SmartHover/GemHoverImage/GemHoverImageEmpty.dds", self.data_path, self.file_system)
                 if skill_gem.get("ui_image", None) not in (None, ''):
                     export_image(skill_gem["ui_image"], self.data_path, self.file_system)
                 if skill_gem["icon_dds_file"] not in (None, ''):


### PR DESCRIPTION
Some skills don't have "ui images" (which appear in the top right of the tooltip), and instead display a default fallback image. This PR ensures this fallback image is exported, without actually adding the path to gems to avoid unnecessarily bloating the JSON.

Related to issue #21 