### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -24,6 +24,6 @@ jobs:
       id: set-version
       run: echo "version=$(cat RePoE/version.txt) / $(cat RePoE/version2.txt)" >> "$GITHUB_OUTPUT"
     - name: commit changes
-      uses: stefanzweifel/git-auto-commit-action@v5.1.0
+      uses: stefanzweifel/git-auto-commit-action@v5.2.0
       with:
         commit_message: "Version ${{ steps.set-version.outputs.version }}"

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install poetry
         run: pipx install 'poetry~=1.8'
       - name: setup python
-        uses: actions/setup-python@v5.4.0
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: "3.11"
           cache: poetry
@@ -76,7 +76,7 @@ jobs:
         working-directory: RePoE/RePoE/data/
       - name: commit changes
         id: autocommit
-        uses: stefanzweifel/git-auto-commit-action@v5.1.0
+        uses: stefanzweifel/git-auto-commit-action@v5.2.0
         with:
           repository: RePoE
           commit_message: "[skip ci] Automated export"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action)** published a new release **[v5.2.0](https://github.com/stefanzweifel/git-auto-commit-action/releases/tag/v5.2.0)** on 2025-04-19T08:39:42Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.6.0](https://github.com/actions/setup-python/releases/tag/v5.6.0)** on 2025-04-24T02:50:16Z
