### PR TITLE
add skill icon export fallback

### DIFF
--- a/RePoE/parser/poe2/skill_gems.py
+++ b/RePoE/parser/poe2/skill_gems.py
@@ -26,6 +26,15 @@ def get_4k_path(path: str):
     return "/".join(parts)
 
 
+def get_non_4k_path(path: str):
+    if path is None:
+        return None
+    parts = path.split("/")
+    if len(parts) >= 2 and parts[-2] == "4k":
+        del parts[-2]
+    return "/".join(parts)
+
+
 def convert_gem(skill_gem: DatRecord, gem_effect: DatRecord, support_gem_icons: Dict[int, str]) -> Dict[str, Any]:
     obj = {}
 
@@ -100,7 +109,13 @@ class skill_gems(Parser_Module):
                 if skill_gem.get("ui_image", None) not in (None, ""):
                     export_image(skill_gem["ui_image"], self.data_path, self.file_system)
                 if skill_gem["icon_dds_file"] not in (None, ""):
-                    export_image(skill_gem["icon_dds_file"], self.data_path, self.file_system)
+                    exported = export_image(skill_gem["icon_dds_file"], self.data_path, self.file_system)
+                    # some skills do not have 4k icons, so fallback to non-4k in those cases
+                    if not exported:
+                        fallback_icon = get_non_4k_path(skill_gem["icon_dds_file"])
+                        if fallback_icon != skill_gem["icon_dds_file"]:
+                            if export_image(fallback_icon, self.data_path, self.file_system):
+                                skill_gem["icon_dds_file"] = fallback_icon
 
         write_any_json(skill_gems, self.data_path, "skill_gems")
 

--- a/RePoE/parser/util.py
+++ b/RePoE/parser/util.py
@@ -200,10 +200,10 @@ def export_image(
     outfile: str | None = None,
     extensions=[".png", ".webp"],
     compose: Callable[[Image], Image] | None = None,
-) -> None:
+) -> bool:
     dest = os.path.join(data_path, os.path.splitext(outfile or ddsfile)[0])
     if dest in exported_images:
-        return
+        return True
     exported_images.add(dest)
     os.makedirs(os.path.dirname(dest), exist_ok=True)
 
@@ -212,16 +212,17 @@ def export_image(
     except Exception:
         print(f"Failed to extract {ddsfile}")
         traceback.print_exc()
-        return
+        return False
     if not bytes:
         print(f"dds file not found {ddsfile}")
-        return
+        return False
     if bytes[:4] != b"DDS ":
         print(f"{ddsfile} was not a dds file")
-        return
+        return False
 
     with Image.open(BytesIO(bytes)) as image:
         if compose:
             image = compose(image)
         for ext in extensions:
             image.save(dest + ext)
+    return True


### PR DESCRIPTION
## Summary
- fall back from 4k gem icon DDS paths to the non-4k asset when the 4k export fails
- update `skill_gems` output so `icon_dds_file` is rewritten to the non-4k path when that fallback is used
- return a success flag from `export_image` so callers can handle missing DDS assets explicitly

## Why
Some skill gems do not have 4k icon assets. The parser was exporting only the derived 4k path, which failed silently and left the gem data pointing at an asset that does not exist.
